### PR TITLE
fix: added custom dumper for pm4ml merge function

### DIFF
--- a/terraform/gitlab/ci-templates/k8s-cluster/.gitlab/scripts/dictmerge.py
+++ b/terraform/gitlab/ci-templates/k8s-cluster/.gitlab/scripts/dictmerge.py
@@ -15,6 +15,14 @@ import os
 
 yaml.Dumper.ignore_aliases = lambda *args : True
 
+# Custom Dumper to handle single quoted integers
+class CustomDumper(yaml.Dumper):
+    def represent_data(self, data):
+        if isinstance(data, str) and data.isdigit():
+            return self.represent_scalar('tag:yaml.org,2002:str', data, style="'")
+
+        return super(CustomDumper, self).represent_data(data)
+
 def mergedicts(dict1, dict2):
     for k in set(dict1.keys()).union(dict2.keys()):
         if k in dict1 and k in dict2:
@@ -118,7 +126,7 @@ if fileName == "pm4ml-vars.yaml":
         mergedItems.append(dict(mergedicts(data1, item)))
     mergedDict["pm4mls"] = mergedItems
     with open(outputFilename, 'w') as file:
-        yaml.dump(mergedDict, file, indent=4 , default_flow_style=False)
+        yaml.dump(mergedDict, file, indent=4 , default_flow_style=False, Dumper=CustomDumper)
 
 elif fileName in ( "common-stateful-resources.json" , "mojaloop-stateful-resources.json" , "mojaloop-rbac-api-resources.yaml" ):
     mergeListOfDicts(data1, data2, fileName, outputFilename, defaultExt)


### PR DESCRIPTION
In custom_config/pm4ml-vars.yaml, if we pass the following values
```
core_connector_config:
  enabled: true
  env:
    TEST1_ID: '0720'
    TEST1_PREFIX: '00002893'
The value '0720' is passing to the generated helm values file correctly but the value '00002893' is being transformed as an integer without preceding zeros like 2893
```
Solution:
Added a custom dumper that works with yaml.dump function
Some explanation about this issue is here
https://github.com/yaml/pyyaml/issues/98#issuecomment-388021094
`A leading zero in YAML 1.1 indicates an octal number, which can only have digits 0-7`