### PR TITLE
Polling freq and backup job freq

### DIFF
--- a/terraform/gitops/generate-files/templates/storage/chart/values.yaml.tpl
+++ b/terraform/gitops/generate-files/templates/storage/chart/values.yaml.tpl
@@ -17,6 +17,7 @@ longhorn:
     replicaAutoBalance: disabled
     autoDeletePodWhenVolumeDetachedUnexpectedly: true
     replicaReplenishmentWaitInterval: 360
+    backupstorePollInterval: 0
     taintToleration: ~
   enablePSP: false
 

--- a/terraform/gitops/generate-files/templates/storage/custom-resources/longhorn-job.yaml.tpl
+++ b/terraform/gitops/generate-files/templates/storage/custom-resources/longhorn-job.yaml.tpl
@@ -5,7 +5,7 @@ metadata:
   annotations:
     argocd.argoproj.io/sync-wave: "${longhorn_job_sync_wave}"
 spec:
-  cron: "0 * * * *"
+  cron: "0 */12 * * *"
   task: "backup"
   groups:
   - default


### PR DESCRIPTION
- Disables longhorn checks on minio for new backups
- Set the cron job to twice a day [once in 12 hours]