### PR TITLE
reduce loki_ingester_pvc_size to 10Gi from 50Gi

### DIFF
--- a/terraform/gitops/k8s-cluster-config/monitoring.tf
+++ b/terraform/gitops/k8s-cluster-config/monitoring.tf
@@ -115,7 +115,7 @@ locals {
   grafana_operator_version            = "3.5.11"
   monitoring_template_path            = "${path.module}/../generate-files/templates/monitoring"
   monitoring_app_file                 = "monitoring-app.yaml"
-  loki_ingester_pvc_size              = "50Gi"
+  loki_ingester_pvc_size              = "10Gi"
   prometheus_pvc_size                 = "50Gi"
   loki_retention_enabled              = true
   loki_ingester_retention_period      = "72h"

--- a/terraform/k8s/default-config/common-vars.yaml
+++ b/terraform/k8s/default-config/common-vars.yaml
@@ -26,7 +26,7 @@ grafana_operator_version: 3.5.11
 grafana_version: 10.2.3
 tempo_chart_version: 2.6.0
 loki_chart_version: 2.13.0
-loki_ingester_pvc_size: 50Gi
+loki_ingester_pvc_size: 10Gi
 prometheus_pvc_size: 50Gi
 loki_retention_enabled: true
 loki_ingester_retention_period: 72h


### PR DESCRIPTION
We no longer need a huge PV for loki since we are using minio buckets for log retension. 