### PR TITLE
rm consul inject

### DIFF
--- a/terraform/gitops/generate-files/templates/consul/values.yaml.tpl
+++ b/terraform/gitops/generate-files/templates/consul/values.yaml.tpl
@@ -9,3 +9,5 @@ consul:
     storage: ${storage_size}
     replicas: ${consul_replicas}
     storageClass: ${storage_class_name}
+  connectInject:
+    enabled: false


### PR DESCRIPTION
consul inject is used as a part of consul service mesh which we do not use.  disabling this injection as it can cause issues with:

deployment of all components will call the consul injector webhooks and the consul webhooks are dependent on consul running and consul is dependent on longhorn (pvc) to run so a infinite loop can get created:

longhorn pod on node where consul pvc is running needs to restart -> consul pvc not available -> consul not ready -> consul webhook service not ready (crashloopbackoff) -> longhorn pod can’t be provisioned because of failure to call consul webhook