### PR TITLE
IPROD-668: Update command and args of loki memcached

### DIFF
--- a/terraform/gitops/generate-files/templates/monitoring/install/values-loki.yaml.tpl
+++ b/terraform/gitops/generate-files/templates/monitoring/install/values-loki.yaml.tpl
@@ -77,6 +77,9 @@ memcachedchunks:
   args:
     # medium profile memory-limit: 1536Mi. Setting value slightly below that.
     # See https://github.com/memcached/memcached/wiki/ConfiguringServer#commandline-arguments
+    # We only updated memory-limit and max-item-size
+    # We did not add extended params related to external store because as of now, we keep all our cache in memory.
+    # We did not change "aggressive" configs for memcache client in loki since memcache is completely RAM backed as of now.
     - "--memory-limit=1400"   # max memory limit for all cached items in mega bytes
     - "--max-item-size=2m"    # max memory limit for a single item
   nodeAffinityPreset:

--- a/terraform/gitops/generate-files/templates/monitoring/install/values-loki.yaml.tpl
+++ b/terraform/gitops/generate-files/templates/monitoring/install/values-loki.yaml.tpl
@@ -70,6 +70,15 @@ queryFrontend:
     values: ["enabled"]
 
 memcachedchunks:
+  resourcesPreset: medium # https://github.com/bitnami/charts/blob/main/bitnami/common/templates/_resources.tpl
+  command:
+    - "/opt/bitnami/scripts/memcached/entrypoint.sh"
+    - "/opt/bitnami/scripts/memcached/run.sh"
+  args:
+    # medium profile memory-limit: 1536Mi. Setting value slightly below that.
+    # See https://github.com/memcached/memcached/wiki/ConfiguringServer#commandline-arguments
+    - "--memory-limit=1400"   # max memory limit for all cached items in mega bytes
+    - "--max-item-size=2m"    # max memory limit for a single item
   nodeAffinityPreset:
     type: hard
     key: workload-class.mojaloop.io/MONITORING


### PR DESCRIPTION
This PR updates memcache configs based on https://github.com/memcached/memcached/wiki/ConfiguringLokiExtstore

- We only updated `memory-limit` and `max-item-size`
- We did not add extended params related to external store. As of now, we keep all our cache in memory. 
- We do not change "aggressive" configs for memcache client in loki since memcache is completely RAM backed as of now.    