### PR TITLE
All mojaloop grafana dashboards use same git tag

### DIFF
--- a/terraform/gitops/generate-files/templates/mojaloop/grafana.yaml.tpl
+++ b/terraform/gitops/generate-files/templates/mojaloop/grafana.yaml.tpl
@@ -111,7 +111,7 @@ spec:
   datasources:
     - inputName: "DS_PROMETHEUS"
       datasourceName: "Prometheus" 
-  url: "https://raw.githubusercontent.com/mojaloop/ml-core-test-harness/v1.2.4-snapshot.0/docker/grafana/provisioning/dashboards/mojaloop/dashboard-quoting-service.json"
+  url: "https://raw.githubusercontent.com/mojaloop/helm/v${grafana_dashboard_tag}/monitoring/dashboards/mojaloop/dashboard-quoting-service.json"
 ---
 apiVersion: grafana.integreatly.org/v1beta1
 kind: GrafanaDashboard
@@ -126,5 +126,5 @@ spec:
   datasources:
     - inputName: "DS_PROMETHEUS"
       datasourceName: "Prometheus" 
-  url: "https://raw.githubusercontent.com/mojaloop/helm/v16.1.0-snapshot.7/monitoring/dashboards/mojaloop/dashboard-performance-troubleshooting.json"
+  url: "https://raw.githubusercontent.com/mojaloop/helm/v${grafana_dashboard_tag}/monitoring/dashboards/mojaloop/dashboard-performance-troubleshooting.json"
 ---

--- a/terraform/k8s/default-config/mojaloop-vars.yaml
+++ b/terraform/k8s/default-config/mojaloop-vars.yaml
@@ -7,7 +7,7 @@ mcm_ingress_internal_lb: false
 mojaloop_ingress_internal_lb: true
 finance_portal_ingress_internal_lb: true
 onboarding_collection_tag: 15.2.0
-grafana_dashboard_tag: 16.1.1-snapshot.2
+grafana_dashboard_tag: 16.1.1-snapshot.2 # TODO: update once v16.1.x is published
 enable_istio_injection: true
 central_ledger_handler_transfer_position_batch_processing_enabled: false
 central_ledger_handler_transfer_position_batch_size: 100

--- a/terraform/k8s/default-config/mojaloop-vars.yaml
+++ b/terraform/k8s/default-config/mojaloop-vars.yaml
@@ -7,7 +7,7 @@ mcm_ingress_internal_lb: false
 mojaloop_ingress_internal_lb: true
 finance_portal_ingress_internal_lb: true
 onboarding_collection_tag: 15.2.0
-grafana_dashboard_tag: 15.2.0
+grafana_dashboard_tag: 16.1.1-snapshot.2
 enable_istio_injection: true
 central_ledger_handler_transfer_position_batch_processing_enabled: false
 central_ledger_handler_transfer_position_batch_size: 100


### PR DESCRIPTION
## changes
- move quoting-service dashboard to mojaloop/helm
- use `grafana_dashboard_tag` variable to define dashboard-performance-troubleshooting