### PR TITLE
Feature/cto 88

### DIFF
--- a/terraform/config-params/control-center-post-config/variables.tf
+++ b/terraform/config-params/control-center-post-config/variables.tf
@@ -103,10 +103,10 @@ variable "private_subdomain_string" {
 
 variable "env_token_period" {
   description = "indicates that the token generated using this role should never expire. The token should be renewed within the duration specified by this value. At each renewal, the token's TTL will be set to the value of this field. Specified in seconds"
-  default = "7776000"   # 90 days
+  default = "60" # "7776000"   # 90 days
 }
 
 variable "env_token_explicit_max_ttl" {
   description = "Tokens can have an explicit max TTL set on them. This value becomes a hard limit on the token's lifetime in seconds"
-  default = "7776000"   # 90 days
+  default = "60" # "7776000"   # 90 days
 }

--- a/terraform/config-params/control-center-post-config/variables.tf
+++ b/terraform/config-params/control-center-post-config/variables.tf
@@ -103,10 +103,10 @@ variable "private_subdomain_string" {
 
 variable "env_token_period" {
   description = "indicates that the token generated using this role should never expire. The token should be renewed within the duration specified by this value. At each renewal, the token's TTL will be set to the value of this field. Specified in seconds"
-  default = "60" # "7776000"   # 90 days
+  default = "7776000"   # 90 days
 }
 
 variable "env_token_explicit_max_ttl" {
   description = "Tokens can have an explicit max TTL set on them. This value becomes a hard limit on the token's lifetime in seconds"
-  default = "60" # "7776000"   # 90 days
+  default = "7776000"   # 90 days
 }

--- a/terraform/config-params/control-center-post-config/variables.tf
+++ b/terraform/config-params/control-center-post-config/variables.tf
@@ -100,3 +100,13 @@ variable "private_subdomain_string" {
   description = "the string in the internal subdomain to distiguish with publci subdomain"
   default     = "internal"
 }
+
+variable "env_token_period" {
+  description = "indicates that the token generated using this role should never expire. The token should be renewed within the duration specified by this value. At each renewal, the token's TTL will be set to the value of this field. Specified in seconds"
+  default = "7776000"   # 90 days
+}
+
+variable "env_token_explicit_max_ttl" {
+  description = "Tokens can have an explicit max TTL set on them. This value becomes a hard limit on the token's lifetime in seconds"
+  default = "7776000"   # 90 days
+}

--- a/terraform/config-params/control-center-post-config/vault-transit.tf
+++ b/terraform/config-params/control-center-post-config/vault-transit.tf
@@ -44,7 +44,7 @@ EOT
 resource "vault_token_auth_backend_role" "vault_token_auth_backend_role" {
   for_each               = var.env_map  
   role_name              = "${each.key}-auth-backend-role"
-  token_period           = "86400"
+  token_period           = "3600"
   token_explicit_max_ttl = "115200"
 }
 

--- a/terraform/config-params/control-center-post-config/vault-transit.tf
+++ b/terraform/config-params/control-center-post-config/vault-transit.tf
@@ -38,6 +38,10 @@ path "${vault_mount.transit.path}/encrypt/${vault_transit_secret_backend_key.uns
 path "${vault_mount.transit.path}/decrypt/${vault_transit_secret_backend_key.unseal_key[each.key].name}" {
   capabilities = [ "update" ]
 }
+
+path "auth/token/roles/${each.key}-auth-backend-role" {
+  capabilities = ["read", "list"]
+}
 EOT
 }
 
@@ -46,6 +50,7 @@ resource "vault_token_auth_backend_role" "vault_token_auth_backend_role" {
   role_name              = "${each.key}-auth-backend-role"
   token_period           = var.env_token_period
   token_explicit_max_ttl = var.env_token_explicit_max_ttl
+  allowed_policies       = [vault_policy.env_transit[each.key].name]
 }
 
 resource "vault_token" "env_token" {

--- a/terraform/config-params/control-center-post-config/vault-transit.tf
+++ b/terraform/config-params/control-center-post-config/vault-transit.tf
@@ -39,28 +39,28 @@ path "${vault_mount.transit.path}/decrypt/${vault_transit_secret_backend_key.uns
   capabilities = [ "update" ]
 }
 
-#path "auth/token/roles/${each.key}-auth-backend-role" {
-#  capabilities = ["read", "list"]
-#}
+path "auth/token/roles/${each.key}-auth-backend-role" {
+  capabilities = ["read", "list"]
+}
+path "auth/token/lookup-self" {
+  capabilities = ["read", "list"]  
+}
 EOT
 }
 
-#resource "vault_token_auth_backend_role" "vault_token_auth_backend_role" {
-#  for_each               = var.env_map  
-#  role_name              = "${each.key}-auth-backend-role"
-#  token_period           = var.env_token_period
-#  token_explicit_max_ttl = var.env_token_explicit_max_ttl
-#  allowed_policies       = [vault_policy.env_transit[each.key].name]
-#}
+resource "vault_token_auth_backend_role" "vault_token_auth_backend_role" {
+  for_each               = var.env_map  
+  role_name              = "${each.key}-auth-backend-role"
+  token_period           = var.env_token_period
+  token_explicit_max_ttl = var.env_token_explicit_max_ttl
+  allowed_policies       = [vault_policy.env_transit[each.key].name]
+}
 
 resource "vault_token" "env_token" {
   for_each  = var.env_map
   policies  = [vault_policy.env_transit[each.key].name]
   no_parent = true
-  
-  #role_name = vault_token_auth_backend_role.vault_token_auth_backend_role[each.key].role_name
-  ttl              = var.env_token_period
-  explicit_max_ttl = var.env_token_explicit_max_ttl
+  role_name = vault_token_auth_backend_role.vault_token_auth_backend_role[each.key].role_name
 }
 
 resource "vault_kv_secret_v2" "env_token" {

--- a/terraform/config-params/control-center-post-config/vault-transit.tf
+++ b/terraform/config-params/control-center-post-config/vault-transit.tf
@@ -44,8 +44,8 @@ EOT
 resource "vault_token_auth_backend_role" "vault_token_auth_backend_role" {
   for_each               = var.env_map  
   role_name              = "${each.key}-auth-backend-role"
-  token_period           = "3600"
-  token_explicit_max_ttl = "115200"
+  token_period           = var.env_token_period
+  token_explicit_max_ttl = var.env_token_explicit_max_ttl
 }
 
 resource "vault_token" "env_token" {

--- a/terraform/config-params/control-center-post-config/vault-transit.tf
+++ b/terraform/config-params/control-center-post-config/vault-transit.tf
@@ -41,10 +41,18 @@ path "${vault_mount.transit.path}/decrypt/${vault_transit_secret_backend_key.uns
 EOT
 }
 
+resource "vault_token_auth_backend_role" "vault_token_auth_backend_role" {
+  for_each               = var.env_map  
+  role_name              = "${each.key}-auth-backend-role"
+  token_period           = "86400"
+  token_explicit_max_ttl = "115200"
+}
+
 resource "vault_token" "env_token" {
   for_each  = var.env_map
   policies  = [vault_policy.env_transit[each.key].name]
   no_parent = true
+  role_name = [vault_token_auth_backend_role.vault_token_auth_backend_role[each.key].role_name]
 }
 
 resource "vault_kv_secret_v2" "env_token" {

--- a/terraform/config-params/control-center-post-config/vault-transit.tf
+++ b/terraform/config-params/control-center-post-config/vault-transit.tf
@@ -52,7 +52,7 @@ resource "vault_token" "env_token" {
   for_each  = var.env_map
   policies  = [vault_policy.env_transit[each.key].name]
   no_parent = true
-  role_name = [vault_token_auth_backend_role.vault_token_auth_backend_role[each.key].role_name]
+  role_name = vault_token_auth_backend_role.vault_token_auth_backend_role[each.key].role_name
 }
 
 resource "vault_kv_secret_v2" "env_token" {

--- a/terraform/config-params/control-center-post-config/vault-transit.tf
+++ b/terraform/config-params/control-center-post-config/vault-transit.tf
@@ -39,28 +39,30 @@ path "${vault_mount.transit.path}/decrypt/${vault_transit_secret_backend_key.uns
   capabilities = [ "update" ]
 }
 
-path "auth/token/roles/${each.key}-auth-backend-role" {
+/*path "auth/token/roles/${each.key}-auth-backend-role" {
   capabilities = ["read", "list"]
 }
 path "auth/token/lookup-self" {
   capabilities = ["read", "list"]  
-}
+}*/
 EOT
 }
 
-resource "vault_token_auth_backend_role" "vault_token_auth_backend_role" {
+/*resource "vault_token_auth_backend_role" "vault_token_auth_backend_role" {
   for_each               = var.env_map  
   role_name              = "${each.key}-auth-backend-role"
   token_period           = var.env_token_period
   token_explicit_max_ttl = var.env_token_explicit_max_ttl
   allowed_policies       = [vault_policy.env_transit[each.key].name]
-}
+}*/
 
 resource "vault_token" "env_token" {
   for_each  = var.env_map
   policies  = [vault_policy.env_transit[each.key].name]
   no_parent = true
-  role_name = vault_token_auth_backend_role.vault_token_auth_backend_role[each.key].role_name
+  #role_name = vault_token_auth_backend_role.vault_token_auth_backend_role[each.key].role_name
+  ttl       =  var.env_token_period
+  explicit_max_ttl = var.env_token_explicit_max_ttl
 }
 
 resource "vault_kv_secret_v2" "env_token" {

--- a/terraform/config-params/control-center-post-config/vault-transit.tf
+++ b/terraform/config-params/control-center-post-config/vault-transit.tf
@@ -39,25 +39,28 @@ path "${vault_mount.transit.path}/decrypt/${vault_transit_secret_backend_key.uns
   capabilities = [ "update" ]
 }
 
-path "auth/token/roles/${each.key}-auth-backend-role" {
-  capabilities = ["read", "list"]
-}
+#path "auth/token/roles/${each.key}-auth-backend-role" {
+#  capabilities = ["read", "list"]
+#}
 EOT
 }
 
-resource "vault_token_auth_backend_role" "vault_token_auth_backend_role" {
-  for_each               = var.env_map  
-  role_name              = "${each.key}-auth-backend-role"
-  token_period           = var.env_token_period
-  token_explicit_max_ttl = var.env_token_explicit_max_ttl
-  allowed_policies       = [vault_policy.env_transit[each.key].name]
-}
+#resource "vault_token_auth_backend_role" "vault_token_auth_backend_role" {
+#  for_each               = var.env_map  
+#  role_name              = "${each.key}-auth-backend-role"
+#  token_period           = var.env_token_period
+#  token_explicit_max_ttl = var.env_token_explicit_max_ttl
+#  allowed_policies       = [vault_policy.env_transit[each.key].name]
+#}
 
 resource "vault_token" "env_token" {
   for_each  = var.env_map
   policies  = [vault_policy.env_transit[each.key].name]
   no_parent = true
-  role_name = vault_token_auth_backend_role.vault_token_auth_backend_role[each.key].role_name
+  
+  #role_name = vault_token_auth_backend_role.vault_token_auth_backend_role[each.key].role_name
+  ttl              = var.env_token_period
+  explicit_max_ttl = var.env_token_explicit_max_ttl
 }
 
 resource "vault_kv_secret_v2" "env_token" {

--- a/terraform/config-params/control-center-post-config/vault-transit.tf
+++ b/terraform/config-params/control-center-post-config/vault-transit.tf
@@ -38,30 +38,16 @@ path "${vault_mount.transit.path}/encrypt/${vault_transit_secret_backend_key.uns
 path "${vault_mount.transit.path}/decrypt/${vault_transit_secret_backend_key.unseal_key[each.key].name}" {
   capabilities = [ "update" ]
 }
-
-/*path "auth/token/roles/${each.key}-auth-backend-role" {
-  capabilities = ["read", "list"]
-}
-path "auth/token/lookup-self" {
-  capabilities = ["read", "list"]  
-}*/
 EOT
 }
 
-/*resource "vault_token_auth_backend_role" "vault_token_auth_backend_role" {
-  for_each               = var.env_map  
-  role_name              = "${each.key}-auth-backend-role"
-  token_period           = var.env_token_period
-  token_explicit_max_ttl = var.env_token_explicit_max_ttl
-  allowed_policies       = [vault_policy.env_transit[each.key].name]
-}*/
 
 resource "vault_token" "env_token" {
   for_each  = var.env_map
   policies  = [vault_policy.env_transit[each.key].name]
   no_parent = true
-  #role_name = vault_token_auth_backend_role.vault_token_auth_backend_role[each.key].role_name
-  ttl       =  var.env_token_period
+  
+  ttl              =  var.env_token_period
   explicit_max_ttl = var.env_token_explicit_max_ttl
 }
 

--- a/terraform/gitops/generate-files/templates/base-utils/velero-credfile-externalsecret.yaml.tpl
+++ b/terraform/gitops/generate-files/templates/base-utils/velero-credfile-externalsecret.yaml.tpl
@@ -5,7 +5,7 @@ metadata:
     argocd.argoproj.io/sync-wave: "${external_secret_sync_wave}"
   name: ${velero_bsl_credentials_secret}
 spec:
-  refreshInterval: 1h
+  refreshInterval: 5m
 
   secretStoreRef:
     kind: ClusterSecretStore

--- a/terraform/gitops/generate-files/templates/base-utils/velero-env-externalsecret.yaml.tpl
+++ b/terraform/gitops/generate-files/templates/base-utils/velero-env-externalsecret.yaml.tpl
@@ -5,7 +5,7 @@ metadata:
     argocd.argoproj.io/sync-wave: "${external_secret_sync_wave}"
   name: ${velero_credentials_secret}
 spec:
-  refreshInterval: 1h
+  refreshInterval: 5m
 
   secretStoreRef:
     kind: ClusterSecretStore

--- a/terraform/gitops/generate-files/templates/certmanager/certman-extsecret.yaml.tpl
+++ b/terraform/gitops/generate-files/templates/certmanager/certman-extsecret.yaml.tpl
@@ -5,7 +5,7 @@ metadata:
   annotations:
     argocd.argoproj.io/sync-wave: "${external_secret_sync_wave}"
 spec:
-  refreshInterval: 1h
+  refreshInterval: 5m
 
   secretStoreRef:
     kind: ClusterSecretStore

--- a/terraform/gitops/generate-files/templates/external-dns/external-secrets/extdns-extsecret.yaml.tpl
+++ b/terraform/gitops/generate-files/templates/external-dns/external-secrets/extdns-extsecret.yaml.tpl
@@ -5,7 +5,7 @@ metadata:
   annotations:
     argocd.argoproj.io/sync-wave: "${external_secret_sync_wave}"
 spec:
-  refreshInterval: 1h
+  refreshInterval: 5m
 
   secretStoreRef:
     kind: ClusterSecretStore

--- a/terraform/gitops/generate-files/templates/monitoring/install/vault-minio-ext-secret.yaml.tpl
+++ b/terraform/gitops/generate-files/templates/monitoring/install/vault-minio-ext-secret.yaml.tpl
@@ -5,7 +5,7 @@ metadata:
   annotations:
     argocd.argoproj.io/sync-wave: "${external_secret_sync_wave}"
 spec:
-  refreshInterval: 1h
+  refreshInterval: 5m
 
   secretStoreRef:
     kind: ClusterSecretStore
@@ -37,7 +37,7 @@ metadata:
   annotations:
     argocd.argoproj.io/sync-wave: "${external_secret_sync_wave}"
 spec:
-  refreshInterval: 1h
+  refreshInterval: 5m
 
   secretStoreRef:
     kind: ClusterSecretStore

--- a/terraform/gitops/generate-files/templates/monitoring/post-config/alertmanager-config.yaml.tpl
+++ b/terraform/gitops/generate-files/templates/monitoring/post-config/alertmanager-config.yaml.tpl
@@ -29,7 +29,7 @@ metadata:
   annotations:
     argocd.argoproj.io/sync-wave: "-11"
 spec:
-  refreshInterval: 1h
+  refreshInterval: 5m
 
   secretStoreRef:
     kind: ClusterSecretStore

--- a/terraform/gitops/generate-files/templates/pm4ml/vault-secret.yaml.tpl
+++ b/terraform/gitops/generate-files/templates/pm4ml/vault-secret.yaml.tpl
@@ -27,7 +27,7 @@ metadata:
   annotations:
     argocd.argoproj.io/sync-wave: "-3"
 spec:
-  refreshInterval: 1h
+  refreshInterval: 5m
 
   secretStoreRef:
     kind: ClusterSecretStore

--- a/terraform/gitops/generate-files/templates/storage/external-secrets/longhorn-extsecret.yaml.tpl
+++ b/terraform/gitops/generate-files/templates/storage/external-secrets/longhorn-extsecret.yaml.tpl
@@ -5,7 +5,7 @@ metadata:
     argocd.argoproj.io/sync-wave: "${external_secret_sync_wave}"
   name: ${longhorn_credentials_secret}
 spec:
-  refreshInterval: 1h
+  refreshInterval: 5m
 
   secretStoreRef:
     kind: ClusterSecretStore

--- a/terraform/gitops/generate-files/templates/vault/vault-extsecret.yaml.tpl
+++ b/terraform/gitops/generate-files/templates/vault/vault-extsecret.yaml.tpl
@@ -5,7 +5,7 @@ metadata:
   annotations:
     argocd.argoproj.io/sync-wave: "${external_secret_sync_wave}"
 spec:
-  refreshInterval: 1h
+  refreshInterval: 5m
 
   secretStoreRef:
     kind: ClusterSecretStore
@@ -28,7 +28,7 @@ metadata:
   annotations:
     argocd.argoproj.io/sync-wave: "${external_secret_sync_wave}"
 spec:
-  refreshInterval: 1h
+  refreshInterval: 5m
 
   secretStoreRef:
     kind: ClusterSecretStore
@@ -51,7 +51,7 @@ metadata:
   annotations:
     argocd.argoproj.io/sync-wave: "${external_secret_sync_wave}"
 spec:
-  refreshInterval: 1h
+  refreshInterval: 5m
 
   secretStoreRef:
     kind: ClusterSecretStore
@@ -74,7 +74,7 @@ metadata:
   annotations:
     argocd.argoproj.io/sync-wave: "${external_secret_sync_wave}"
 spec:
-  refreshInterval: 1h
+  refreshInterval: 5m
 
   secretStoreRef:
     kind: ClusterSecretStore

--- a/terraform/gitops/stateful-resources/templates/stateful-resources/managed-crs.yaml.tpl
+++ b/terraform/gitops/stateful-resources/templates/stateful-resources/managed-crs.yaml.tpl
@@ -8,7 +8,7 @@ metadata:
   annotations:
     argocd.argoproj.io/sync-wave: "-11"
 spec:
-  refreshInterval: 1h
+  refreshInterval: 5m
 
   secretStoreRef:
     kind: ClusterSecretStore

--- a/terraform/gitops/stateful-resources/templates/stateful-resources/percona/mongodb/db-cluster.yaml.tpl
+++ b/terraform/gitops/stateful-resources/templates/stateful-resources/percona/mongodb/db-cluster.yaml.tpl
@@ -620,7 +620,7 @@ metadata:
   name: ${percona_credentials_secret}
   namespace: ${namespace}
 spec:
-  refreshInterval: 1h
+  refreshInterval: 5m
 
   secretStoreRef:
     kind: ClusterSecretStore

--- a/terraform/gitops/stateful-resources/templates/stateful-resources/percona/mysql/db-cluster.yaml.tpl
+++ b/terraform/gitops/stateful-resources/templates/stateful-resources/percona/mysql/db-cluster.yaml.tpl
@@ -739,7 +739,7 @@ metadata:
   name: ${percona_credentials_secret}
   namespace: ${namespace}
 spec:
-  refreshInterval: 1h
+  refreshInterval: 5m
 
   secretStoreRef:
     kind: ClusterSecretStore


### PR DESCRIPTION
- When the auth token named env_token gets expired in tenancy vault, the clusterSecretStore tenant-vault-secret-store will be in a “validatationFailed” status. Along with this, all external secrets will be failing to retrieve the secret from tenancy vault and all apps related to the externalSecrets will be failed to run. 

- The default TTL of the auth token - “env_token” is observed to be 32 days. The PR code changes would change the TTL to 90 days. 
- The PR sets the refreshInterval of all external secrets to 5minutes , earlier it was 1 hour. All external secrets will be able to refresh itself after the token regeneration and successfully retrieve the secrets from tenancy vault.   