### PR TITLE
Support more than one cluster with managed RDS

### DIFF
--- a/terraform/aws/support-svcs/deploy-rds/infra.tf
+++ b/terraform/aws/support-svcs/deploy-rds/infra.tf
@@ -8,7 +8,7 @@ module "rds" {
   for_each   = var.rds_services
   source     = "terraform-aws-modules/rds/aws"
 
-  identifier = each.key
+  identifier = "${var.deployment_name}-${each.key}"
 
   engine              = each.value.external_resource_config.engine
   engine_version      = each.value.external_resource_config.engine_version
@@ -30,7 +30,7 @@ module "rds" {
   # Enhanced Monitoring - see example for details on how to create the role
   # by yourself, in case you don't want to create it automatically
   monitoring_interval    = each.value.external_resource_config.monitoring_interval
-  monitoring_role_name   = "${each.value.external_resource_config.db_name}-RDSMonitoringRole"
+  monitoring_role_name   = "${var.deployment_name}-${each.value.external_resource_config.db_name}-RDSMonitoringRole"
   create_monitoring_role = true
 
   tags = each.value.external_resource_config.tags

--- a/terraform/k8s/default-config/cluster-config.yaml
+++ b/terraform/k8s/default-config/cluster-config.yaml
@@ -35,6 +35,7 @@ nodes:
       workload-class.mojaloop.io/RDBMS-ALS-LIVE: "enabled"
       workload-class.mojaloop.io/MONITORING: "enabled"
 vpc_cidr: "10.106.0.0/23"
+managed_vpc_cidr: "10.28.0.0/23"
 enable_k6s_test_harness: false
 k6s_docker_server_instance_type: "m5.large"
 master_node_supports_traffic: true

--- a/terraform/k8s/managed-services/terragrunt.hcl
+++ b/terraform/k8s/managed-services/terragrunt.hcl
@@ -11,6 +11,8 @@ include "root" {
 inputs = {
   tags                         = local.tags
   deployment_name              = local.CLUSTER_NAME
+  vpc_cidr                     = local.env_vars.managed_vpc_cidr
+
 
   managed_stateful_resources_config_file  = find_in_parent_folders("${get_env("CONFIG_PATH")}/mojaloop-stateful-resources-managed.yaml")
   platform_stateful_resources_config_file = find_in_parent_folders("${get_env("CONFIG_PATH")}/platform-stateful-resources.yaml")


### PR DESCRIPTION
- added clustername as prefix to the names of managed rds resources.
- added config parameter to customise the cidr of managed services vpc.