### PR TITLE
feat: allow triggering for continuous deployment

### DIFF
--- a/terraform/gitlab/ci-templates/k8s-cluster/.gitlab-ci.yml
+++ b/terraform/gitlab/ci-templates/k8s-cluster/.gitlab-ci.yml
@@ -254,4 +254,5 @@ refresh-deploy-infra:
     when: always
   rules:
     - if: $CI_COMMIT_BRANCH == $CI_DEFAULT_BRANCH && $CI_COMMIT_TITLE =~ /^deploy.*/
+    - if: $CI_PIPELINE_TRIGGERED
     - when: manual


### PR DESCRIPTION
This will run the `refresh-deploy-infra` job when the pipeline is triggered with a trigger token. This allows updates in the [continuous deployment profile](https://github.com/infitx-org/profile-cd) to trigger new deployments via the GitHub action in that profile.

As per the docs here https://docs.gitlab.com/ee/ci/triggers/#configure-cicd-jobs-to-run-in-triggered-pipelines
> Additionally, the $CI_PIPELINE_TRIGGERED predefined CI/CD variable is set to true in pipelines triggered with a pipeline trigger token.