### PR TITLE
feat: addons

### DIFF
--- a/docs/addons.md
+++ b/docs/addons.md
@@ -1,0 +1,121 @@
+# Addons
+
+Addons provide a way to install additional applications that are loosely coupled
+to the Mojaloop platform.
+
+## Addon structure
+
+Addons are defined as subdirectories in the `addons` directory.
+Each subdirectory includes tha apps that are part of the addon.
+See the diagram below for the meaning of each directory and file:
+
+```text
+├──📁 addons
+|   ├──📁 addon-name-1
+|   |   ├──📁 app-yamls              # define apps for the root app
+|   |   |   ├── app-1.yaml
+|   |   |   └── app-2.yaml
+|   |   ├──📁 app-1                  # k8s resources for app-1
+|   |   |   ├── kustomization.yaml
+|   |   |   ├── values-default.yaml  # default values for app-1
+|   |   |   ├── values-override.yaml # template for overrides
+|   |   |   ├── vs.yaml              # virtual service for app-1
+|   |   |   └── ...
+|   |   ├──📁 app-2                 # k8s resources for app-2
+|   |   └── default.yaml            # default values for addon-name-1
+|   └──📁 addon-name-2
+|       ├──📁 app-yamls             # define apps for the root app
+|       ├──📁 app-3                 # k8s resources for app-3
+|       ├──📁 app-4                 # k8s resources for app-2
+|       └──📁 ...
+├──📁 custom-config
+|   ├── app-yamls.yaml
+|   ├── app-1.yaml
+|   ├── app-2.yaml
+|   ├── app-3.yaml
+|   └── app-4.yaml
+```
+
+## Addon configuration
+
+Addons are configured using several files:
+
+- `addons/<addon-name>/default.yaml`: default values for the addon
+
+  Example:
+
+  ```yaml
+  app-yamls:
+      app-1:
+        enabled: true
+        syncWave: 0
+        namespace: app-1
+      app-2:
+        enabled: true
+        syncWave: 0
+        namespace: app-2
+
+  app-1:
+      version: 2.7.0
+      values: {}
+
+  app-2:
+      version: 0.7.26
+      tag: v2.6.0
+      values: {}
+  ```
+
+- `addons/<addon-name>/<app-name>/values-default.yaml`: default values for each app
+
+  Example:
+
+  ```yaml
+  image:
+    tag: ${app.tag}
+  config:
+    oidc:
+      clientID: test
+  ```
+
+- `custom-config/app-yamls.yaml`: onvironment overrides for ArgoCD app settings
+
+  Example:
+
+  ```yaml
+  app-1:
+    enabled: false              # disable app-1
+  app-2:
+    namespace: new-namespace    # change the namespace for app-2
+    syncWave: 1                 # move app-2 to sync wave 1
+  ```
+
+- `custom-config/<app-name>.yaml`: environment overrides for app-name
+
+  Example:
+
+  ```yaml
+  values:           # chart values overrides
+    image:
+      tag: v1.0.0   # override the image tag
+  version: 1.0.0    # override the chart version
+  ```
+
+## Reusable addons
+
+To achieve addons, profiles can be cloned as git submodules in the
+addons folder of the respective IAC environment repository.
+
+The easiest way is to achieve that is to use the declarative
+approach and configure the addons in the `submodules.yaml`:
+
+   ```yaml
+   addons/addon-name-1:
+      url: https://example.com/addons/addon-name-1.git
+      ref: stable
+   addons/addon-name-2:
+      url: https://example.com/addons/addon-name-2.git
+      ref: v1.0
+   ```
+
+For more details check the [reusable profiles](profiles.md#reusable-profiles)
+section in the profiles documentation.

--- a/terraform/gitlab/ci-templates/k8s-cluster/.gitlab/scripts/config-merge.sh
+++ b/terraform/gitlab/ci-templates/k8s-cluster/.gitlab/scripts/config-merge.sh
@@ -5,7 +5,7 @@ YAML_ENV_CONFIG=${configFile/%.yaml/.$ENV_TYPE.yaml}
 JSON_ENV_CONFIG=${configFile/%.json/.$ENV_TYPE.json}
 
 mkdir -p $CONFIG_PATH
-for configFile in $(ls default-config/)
+for configFile in $({ ls default-config/; ls custom-config/; } | sort -u)
 do
     echo $configFile
     python3 .gitlab/scripts/dictmerge.py \

--- a/terraform/gitlab/ci-templates/k8s-cluster/.gitlab/scripts/dictmerge.py
+++ b/terraform/gitlab/ci-templates/k8s-cluster/.gitlab/scripts/dictmerge.py
@@ -87,8 +87,7 @@ if os.path.isfile(default_config_file):
        print("File type not supported")
        exit(1)
 else:
-    print("Default config file "+default_config_file+" file does not exist")
-    exit(1)
+    data1 = {}
 
 def load_custom_config(custom_config_file):
     customExt = os.path.splitext(custom_config_file)[1]

--- a/terraform/k8s/addons/generate-apps.tf
+++ b/terraform/k8s/addons/generate-apps.tf
@@ -8,8 +8,6 @@ resource "local_file" "config-file" {
         local.default[basename(dirname(dirname(each.value)))][basename(dirname(each.value))],
         local.override[dirname(each.value)]
       )
-      gitlabUrl : var.gitlabUrl
-      gitlabProjectUrl : var.gitlabProjectUrl
     }
   )
   filename = "${var.outputDir}/${basename(dirname(each.value))}/${basename(each.value)}"
@@ -21,7 +19,7 @@ locals {
     dirname(app) => yamldecode(templatefile(app, var.clusterConfig))
   }
   override = { # load overrides for each addon, keyed by addon-name/folder-name
-    for app in distinct([for _, v in fileset(path.module, "*/*/*"): dirname(v)]) :
+    for app in distinct([for _, v in fileset(path.module, "*/*/*") : dirname(v)]) :
     app => try(yamldecode(templatefile("${var.configPath}/${basename(app)}.yaml", var.clusterConfig)), {})
   }
 }
@@ -35,13 +33,5 @@ variable "configPath" {
 }
 
 variable "outputDir" {
-  type = string
-}
-
-variable "gitlabUrl" {
-  type = string
-}
-
-variable "gitlabProjectUrl" {
   type = string
 }

--- a/terraform/k8s/addons/generate-apps.tf
+++ b/terraform/k8s/addons/generate-apps.tf
@@ -9,6 +9,7 @@ resource "local_file" "config-file" {
         local.override[dirname(each.value)]
       )
       gitlabUrl : var.gitlabUrl
+      gitlabProjectUrl : var.gitlabProjectUrl
     }
   )
   filename = "${var.outputDir}/${basename(dirname(each.value))}/${basename(each.value)}"
@@ -38,5 +39,9 @@ variable "outputDir" {
 }
 
 variable "gitlabUrl" {
+  type = string
+}
+
+variable "gitlabProjectUrl" {
   type = string
 }

--- a/terraform/k8s/addons/generate-apps.tf
+++ b/terraform/k8s/addons/generate-apps.tf
@@ -1,0 +1,42 @@
+resource "local_file" "config-file" {
+  for_each = fileset(path.module, "*/*/*") # this represents addon-name/app-name/filename
+  content = templatefile(
+    "${each.value}",
+    {
+      cluster : var.clusterConfig
+      app : merge(
+        local.default[basename(dirname(dirname(each.value)))][basename(dirname(each.value))],
+        local.override[dirname(each.value)]
+      )
+      gitlabUrl : var.gitlabUrl
+    }
+  )
+  filename = "${var.outputDir}/${basename(dirname(each.value))}/${basename(each.value)}"
+}
+
+locals {
+  default = { # load defaults for each addon, keyed by addon-name
+    for app in fileset(path.module, "*/default.yaml") :
+    dirname(app) => yamldecode(templatefile(app, var.clusterConfig))
+  }
+  override = { # load overrides for each addon, keyed by addon-name/folder-name
+    for app in distinct([for _, v in fileset(path.module, "*/*/*"): dirname(v)]) :
+    app => try(yamldecode(templatefile("${var.configPath}/${basename(app)}.yaml", var.clusterConfig)), {})
+  }
+}
+
+variable "clusterConfig" {
+  type = any
+}
+
+variable "configPath" {
+  type = string
+}
+
+variable "outputDir" {
+  type = string
+}
+
+variable "gitlabUrl" {
+  type = string
+}

--- a/terraform/k8s/addons/terragrunt.hcl
+++ b/terraform/k8s/addons/terragrunt.hcl
@@ -8,8 +8,6 @@ inputs = {
   clusterConfig            = merge(local.clusterConfig, {
     gitlabUrl              = get_env("GITLAB_PROVIDER_URL")
     gitlabProjectUrl       = get_env("GITLAB_PROJECT_URL")
-    kubernetesOidcIssuer   = get_env("KUBERNETES_OIDC_ISSUER")
-    kubernetesOidcClientId = get_env("KUBERNETES_OIDC_CLIENT_ID")
   })
 }
 

--- a/terraform/k8s/addons/terragrunt.hcl
+++ b/terraform/k8s/addons/terragrunt.hcl
@@ -3,11 +3,14 @@ include "root" {
 }
 
 inputs = {
-  outputDir        = get_env("GITOPS_BUILD_OUTPUT_DIR")
-  clusterConfig    = local.clusterConfig
-  configPath       = find_in_parent_folders(get_env("CONFIG_PATH"))
-  gitlabUrl        = get_env("GITLAB_PROVIDER_URL")
-  gitlabProjectUrl = get_env("GITLAB_PROJECT_URL")
+  outputDir                = get_env("GITOPS_BUILD_OUTPUT_DIR")
+  configPath               = find_in_parent_folders(get_env("CONFIG_PATH"))
+  clusterConfig            = merge(local.clusterConfig, {
+    gitlabUrl              = get_env("GITLAB_PROVIDER_URL")
+    gitlabProjectUrl       = get_env("GITLAB_PROJECT_URL")
+    kubernetesOidcIssuer   = get_env("KUBERNETES_OIDC_ISSUER")
+    kubernetesOidcClientId = get_env("KUBERNETES_OIDC_CLIENT_ID")
+  })
 }
 
 locals {

--- a/terraform/k8s/addons/terragrunt.hcl
+++ b/terraform/k8s/addons/terragrunt.hcl
@@ -1,0 +1,47 @@
+include "root" {
+  path = find_in_parent_folders()
+}
+
+inputs = {
+  outputDir     = get_env("GITOPS_BUILD_OUTPUT_DIR")
+  clusterConfig = local.clusterConfig
+  configPath    = get_env("CONFIG_PATH")
+  gitlabUrl     = local.gitlabUrl
+}
+
+locals {
+  skip_outputs  = get_env("CI_COMMIT_BRANCH") != get_env("CI_DEFAULT_BRANCH")
+  clusterConfig = yamldecode(file("${find_in_parent_folders("${get_env("CONFIG_PATH")}/cluster-config.yaml")}"))
+  commonVars    = yamldecode(templatefile("${find_in_parent_folders("${get_env("CONFIG_PATH")}/common-vars.yaml")}", local.clusterConfig))
+  vaultUrl      = get_env("VAULT_ADDR")
+  vaultToken    = get_env("ENV_VAULT_TOKEN")
+  gitlabUrl     = get_env("GITLAB_PROVIDER_URL")
+  gitlabToken   = get_env("GITLAB_PROVIDER_TOKEN")
+}
+
+generate "required_providers_override" {
+  path = "required_providers_override.tf"
+
+  if_exists = "overwrite_terragrunt"
+
+  contents = <<EOF
+terraform {
+
+  required_providers {
+    gitlab = {
+      source = "gitlabhq/gitlab"
+      version = "${local.commonVars.gitlab_provider_version}"
+    }
+    vault = "${local.commonVars.vault_provider_version}"
+  }
+}
+provider "vault" {
+  address = "${local.vaultUrl}"
+  token   = "${local.vaultToken}"
+}
+provider "gitlab" {
+  base_url = "${local.gitlabUrl}"
+  token = "${local.gitlabToken}"
+}
+EOF
+}

--- a/terraform/k8s/addons/terragrunt.hcl
+++ b/terraform/k8s/addons/terragrunt.hcl
@@ -6,17 +6,13 @@ inputs = {
   outputDir     = get_env("GITOPS_BUILD_OUTPUT_DIR")
   clusterConfig = local.clusterConfig
   configPath    = get_env("CONFIG_PATH")
-  gitlabUrl     = local.gitlabUrl
+  gitlabUrl     = get_env("GITLAB_PROJECT_URL")
 }
 
 locals {
   skip_outputs  = get_env("CI_COMMIT_BRANCH") != get_env("CI_DEFAULT_BRANCH")
   clusterConfig = yamldecode(file("${find_in_parent_folders("${get_env("CONFIG_PATH")}/cluster-config.yaml")}"))
   commonVars    = yamldecode(templatefile("${find_in_parent_folders("${get_env("CONFIG_PATH")}/common-vars.yaml")}", local.clusterConfig))
-  vaultUrl      = get_env("VAULT_ADDR")
-  vaultToken    = get_env("ENV_VAULT_TOKEN")
-  gitlabUrl     = get_env("GITLAB_PROVIDER_URL")
-  gitlabToken   = get_env("GITLAB_PROVIDER_TOKEN")
 }
 
 generate "required_providers_override" {
@@ -36,12 +32,12 @@ terraform {
   }
 }
 provider "vault" {
-  address = "${local.vaultUrl}"
-  token   = "${local.vaultToken}"
+  address = "${get_env("VAULT_ADDR")}"
+  token   = "${get_env("ENV_VAULT_TOKEN")}"
 }
 provider "gitlab" {
-  base_url = "${local.gitlabUrl}"
-  token = "${local.gitlabToken}"
+  base_url = "${get_env("GITLAB_PROVIDER_URL")}"
+  token = "${get_env("GITLAB_PROVIDER_TOKEN")}"
 }
 EOF
 }

--- a/terraform/k8s/addons/terragrunt.hcl
+++ b/terraform/k8s/addons/terragrunt.hcl
@@ -5,7 +5,7 @@ include "root" {
 inputs = {
   outputDir     = get_env("GITOPS_BUILD_OUTPUT_DIR")
   clusterConfig = local.clusterConfig
-  configPath    = get_env("CONFIG_PATH")
+  configPath    = find_in_parent_folders(get_env("CONFIG_PATH"))
   gitlabUrl     = get_env("GITLAB_PROJECT_URL")
 }
 

--- a/terraform/k8s/addons/terragrunt.hcl
+++ b/terraform/k8s/addons/terragrunt.hcl
@@ -3,10 +3,11 @@ include "root" {
 }
 
 inputs = {
-  outputDir     = get_env("GITOPS_BUILD_OUTPUT_DIR")
-  clusterConfig = local.clusterConfig
-  configPath    = find_in_parent_folders(get_env("CONFIG_PATH"))
-  gitlabUrl     = get_env("GITLAB_PROJECT_URL")
+  outputDir        = get_env("GITOPS_BUILD_OUTPUT_DIR")
+  clusterConfig    = local.clusterConfig
+  configPath       = find_in_parent_folders(get_env("CONFIG_PATH"))
+  gitlabUrl        = get_env("GITLAB_PROVIDER_URL")
+  gitlabProjectUrl = get_env("GITLAB_PROJECT_URL")
 }
 
 locals {


### PR DESCRIPTION
- Simplified way to install addons like redpanda by listing the addon repository in the `submodules.yaml` file and configuring them in the `custom-config` folder, while the defaults will be taken from the repository of the addon, instead of being replicated in the env.
- Allow default-config to be missing and only custom-config to be present. The `default-config` folder should not really exist in the env repo, as we are not supposed to edit the files in it.

