### PR TITLE
feat: pass filename to addon templates

### DIFF
--- a/terraform/k8s/addons/generate-apps.tf
+++ b/terraform/k8s/addons/generate-apps.tf
@@ -8,6 +8,7 @@ resource "local_file" "config-file" {
         local.default[basename(dirname(dirname(each.value)))][basename(dirname(each.value))],
         local.override[dirname(each.value)]
       )
+      filename: each.value
     }
   )
   filename = "${var.outputDir}/${basename(dirname(each.value))}/${basename(each.value)}"


### PR DESCRIPTION
This will allow templates in the addons to include JSON/YAML via `indent(xxx, file(filename))` instead of embedding them inline and creating big and hard to manage templates, that need escaping, lack syntax highlight, etc.