### PR TITLE
feat: add domain suffix to cluster configuration

### DIFF
--- a/terraform/k8s/addons/terragrunt.hcl
+++ b/terraform/k8s/addons/terragrunt.hcl
@@ -8,6 +8,7 @@ inputs = {
   clusterConfig            = merge(local.clusterConfig, {
     gitlabUrl              = get_env("GITLAB_PROVIDER_URL")
     gitlabProjectUrl       = get_env("GITLAB_PROJECT_URL")
+    domainSuffix           = "${replace(local.clusterConfig.env,"/^.*(-[^-]+)$|^[^-]+([^-]{3})$/","$1$2")}.${local.clusterConfig.domain}"
   })
 }
 

--- a/terraform/k8s/gitops-build/terragrunt.hcl
+++ b/terraform/k8s/gitops-build/terragrunt.hcl
@@ -106,7 +106,10 @@ inputs = {
 
 locals {
   skip_outputs = get_env("CI_COMMIT_BRANCH") != get_env("CI_DEFAULT_BRANCH")
-  env_vars                      = yamldecode(file("${find_in_parent_folders("${get_env("CONFIG_PATH")}/cluster-config.yaml")}"))
+  clusterConfig                 = yamldecode(file("${find_in_parent_folders("${get_env("CONFIG_PATH")}/cluster-config.yaml")}"))
+  env_vars                      = merge(local.clusterConfig, {
+    domainSuffix                = "${replace(local.clusterConfig.env,"/^.*(-[^-]+)$|^[^-]+([^-]{3})$/","$1$2")}.${local.clusterConfig.domain}"
+  })
   tags                          = local.env_vars.tags
   gitlab_readonly_rbac_group    = get_env("GITLAB_READONLY_RBAC_GROUP")
   gitlab_admin_rbac_group       = get_env("GITLAB_ADMIN_RBAC_GROUP")
@@ -114,13 +117,13 @@ locals {
   grafana_user_rbac_group       = get_env("grafana_user_rbac_group")
   vault_admin_rbac_group        = get_env("vault_admin_rbac_group")
   vault_readonly_rbac_group     = get_env("vault_user_rbac_group")
-  zitadel_project_id            = get_env("zitadel_project_id")      
+  zitadel_project_id            = get_env("zitadel_project_id")
   common_vars                   = yamldecode(templatefile("${find_in_parent_folders("${get_env("CONFIG_PATH")}/common-vars.yaml")}", local.env_vars))
   pm4ml_vars                    = yamldecode(templatefile("${find_in_parent_folders("${get_env("CONFIG_PATH")}/pm4ml-vars.yaml")}", local.env_vars))
   proxy_pm4ml_vars              = yamldecode(templatefile("${find_in_parent_folders("${get_env("CONFIG_PATH")}/proxy-pm4ml-vars.yaml")}", local.env_vars))
   mojaloop_vars                 = yamldecode(templatefile("${find_in_parent_folders("${get_env("CONFIG_PATH")}/mojaloop-vars.yaml")}", local.env_vars))
   vnext_vars                    = yamldecode(templatefile("${find_in_parent_folders("${get_env("CONFIG_PATH")}/vnext-vars.yaml")}", local.env_vars))
-   
+
   cloud_platform_vars = merge({
     nat_public_ips                   = [""],
     internal_load_balancer_dns       = "",


### PR DESCRIPTION
The `domainSuffix` is the common suffix shared between the related environments and can be used in templates when these environments need to link between themselves. The currently supported patterns are:
- xxxxx.yyyyy.zzzz`-envname.example.com` - a hyphen separates the suffix, where `envname` can be of varying length
- xxxxx.yyyyy.zzzz`env.example.com` - no hyphen separator, `env` is a 3 character length

Future patterns can be introduced by this variable without breaking the deployments.