### PR TITLE
Very Minor: Change Zitadel Name by removing duplicates

### DIFF
--- a/terraform/config-params/ccnew-config/zitadel/admin.tf
+++ b/terraform/config-params/ccnew-config/zitadel/admin.tf
@@ -1,6 +1,6 @@
 resource "zitadel_human_user" "admin" {
   org_id             = var.zitadel_org_id
-  user_name          = "rootauto@zitadel.${var.zitadel_fqdn}"
+  user_name          = "rootauto@${var.zitadel_fqdn}"
   first_name         = "root"
   last_name          = "admin"
   nick_name          = "admin"


### PR DESCRIPTION
Root User Currently has a double zitadel for example below:

```
root user: rootauto@zitadel.zitadel.controlcenter.cbc.drpp.global
```
This is a proposal to change it to the example below:

```
root user: rootauto@zitadel.controlcenter.cbc.drpp.global
```