### PR TITLE
DONOT MERGE WITHOUT ASKING MUZA: Configure rgw-ceph log level

### DIFF
--- a/assets/grafana-dashboards/loki-storage.json
+++ b/assets/grafana-dashboards/loki-storage.json
@@ -18,7 +18,7 @@
   "editable": true,
   "fiscalYearStartMonth": 0,
   "graphTooltip": 0,
-  "id": 85,
+  "id": 28,
   "links": [],
   "panels": [
     {
@@ -138,7 +138,7 @@
             "uid": "${DS_LOKI}"
           },
           "editorMode": "code",
-          "expr": "sum(bytes_rate({app=~\"${app}\"}[1m])) by (app,container) * 3600*24",
+          "expr": "sum(bytes_rate({app=~\"${app}\"}[10s])) by (app,container) * 3600*24",
           "legendFormat": "",
           "queryType": "range",
           "refId": "A"
@@ -204,8 +204,7 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green",
-                    "value": null
+                    "color": "green"
                   },
                   {
                     "color": "red",
@@ -248,7 +247,7 @@
                 "uid": "${DS_LOKI}"
               },
               "editorMode": "code",
-              "expr": "sum(bytes_rate({app=~\"${app}\"}[1m])) by (app,container)",
+              "expr": "sum(bytes_rate({app=~\"${app}\"}[10s])) by (app,container)",
               "hide": false,
               "legendFormat": "",
               "queryType": "range",
@@ -273,9 +272,9 @@
     "list": [
       {
         "current": {
-          "selected": true,
+          "selected": false,
           "text": "Loki",
-          "value": "53db9978-9c6c-4c8e-bf71-6082f63756e6"
+          "value": "40106cf7-f4a4-4dee-8c80-906ddea18ee0"
         },
         "hide": 0,
         "includeAll": false,
@@ -290,6 +289,7 @@
         "type": "datasource"
       },
       {
+        "allValue": ".+",
         "current": {
           "selected": false,
           "text": "All",
@@ -320,13 +320,13 @@
     ]
   },
   "time": {
-    "from": "now-30s",
+    "from": "now-15s",
     "to": "now"
   },
   "timepicker": {},
   "timezone": "browser",
   "title": "Loki storage",
-  "uid": "bee85ru33l-v002",
-  "version": 4,
+  "uid": "bee85ru33l-v003",
+  "version": 1,
   "weekStart": ""
 }

--- a/gitops/applications/base/rook-ceph/ceph-objectstore-crs.yaml
+++ b/gitops/applications/base/rook-ceph/ceph-objectstore-crs.yaml
@@ -22,5 +22,5 @@ spec:
     instances: 1
     priorityClassName: system-cluster-critical
     rgwCommandFlags:
-      debug_ms: "5"
-      debug_rgw: "5"
+      debug_ms: ${ARGOCD_ENV_rgw_log_level}
+      debug_rgw: ${ARGOCD_ENV_rgw_log_level}

--- a/gitops/applications/base/rook-ceph/ceph-objectstore-crs.yaml
+++ b/gitops/applications/base/rook-ceph/ceph-objectstore-crs.yaml
@@ -21,3 +21,6 @@ spec:
     sslCertificateRef: objectstore-internal-tls
     instances: 1
     priorityClassName: system-cluster-critical
+    rgwCommandFlags:
+      debug_ms: "5"
+      debug_rgw: "5"

--- a/gitops/argo-apps/base/rook-ceph.yaml
+++ b/gitops/argo-apps/base/rook-ceph.yaml
@@ -50,7 +50,7 @@ spec:
               cpu: 50m
               memory: 64Mi
     - repoURL: ${ARGOCD_ENV_argocd_repo_url}
-      targetRevision: ${ARGOCD_ENV_gitlab_application_gitrepo_tag}
+      targetRevision: ${ARGOCD_ENV_utils_application_gitrepo_tag}
       path: gitops/applications/base/rook-ceph
       plugin:
         name: envsubst
@@ -65,7 +65,7 @@ spec:
             value: "${ARGOCD_ENV_utils_rook_ceph_rgw_log_level}"
 
     - repoURL: ${ARGOCD_ENV_argocd_repo_url}
-      targetRevision: ${ARGOCD_ENV_gitlab_application_gitrepo_tag}
+      targetRevision: ${ARGOCD_ENV_utils_application_gitrepo_tag}
       path: gitops/applications/overlays/cloud_provider/${ARGOCD_ENV_dynamic_secret_platform}/rook-ceph-cluster/${ARGOCD_ENV_utils_rook_ceph_volumes_provider}
       plugin:
         name: envsubst

--- a/gitops/argo-apps/base/rook-ceph.yaml
+++ b/gitops/argo-apps/base/rook-ceph.yaml
@@ -61,6 +61,9 @@ spec:
           - name: objects_replica_count
             value: "${ARGOCD_ENV_utils_rook_ceph_objects_replica_count}"
 
+          - name: rgw_log_level
+            value: "${ARGOCD_ENV_utils_rook_ceph_rgw_log_level}"
+
     - repoURL: ${ARGOCD_ENV_argocd_repo_url}
       targetRevision: ${ARGOCD_ENV_gitlab_application_gitrepo_tag}
       path: gitops/applications/overlays/cloud_provider/${ARGOCD_ENV_dynamic_secret_platform}/rook-ceph-cluster/${ARGOCD_ENV_utils_rook_ceph_volumes_provider}

--- a/terraform/ccnew/ansible-k8s-deploy/templates/argoapps.yaml.tpl
+++ b/terraform/ccnew/ansible-k8s-deploy/templates/argoapps.yaml.tpl
@@ -28,6 +28,7 @@ argocd_override:
           volumes_storage_region: "${cloud_region}"
           cluster_domain: "${cluster_domain}"
           aws_ebs_csi_driver_helm_version: "${rook_ceph_aws_ebs_csi_driver_helm_version}"
+          rgw_log_level: "${rook_ceph_rgw_log_level}"
         reflector:
           helm_version: "${reflector_helm_version}"
         reloader:

--- a/terraform/ccnew/default-config/common-vars.yaml
+++ b/terraform/ccnew/default-config/common-vars.yaml
@@ -280,7 +280,7 @@ zitadel_perc_pgdb_helm_version: "2.4.0"
 zitadel_perc_postgres_storage_size: "20Gi"
 # end of zitadel db settins
 # rook ceph
-rook_ceph_helm_version: "1.15.5"
+rook_ceph_helm_version: "1.16.5"
 rook_ceph_image_version: "v18.2.4"
 rook_ceph_mon_volumes_size: "10Gi"
 rook_ceph_osd_volumes_storage_class: "gp3"

--- a/terraform/ccnew/default-config/common-vars.yaml
+++ b/terraform/ccnew/default-config/common-vars.yaml
@@ -292,7 +292,7 @@ rook_ceph_osd_count: "'3'"
 rook_ceph_volume_size_per_osd: "500Gi"
 rook_ceph_volumes_provider: "pvc" # host, pvc
 rook_ceph_aws_ebs_csi_driver_helm_version: "2.39.0"
-
+rook_ceph_rgw_log_level: 0
 
 # argocd 
 argocd_server_log_level: "info"


### PR DESCRIPTION
The PR is blocked because we don't have infra to test it out. Current changes are incompatible with ceph helm version 1.15. We need to increase it to 1.16.0 at least to take effect. 


`rook_ceph_helm_version: "1.16.0"` 