### PR TITLE
fix: istio sidecar for als timeout handler

### DIFF
--- a/terraform/gitops/generate-files/templates/mojaloop/values-mojaloop.yaml.tpl
+++ b/terraform/gitops/generate-files/templates/mojaloop/values-mojaloop.yaml.tpl
@@ -253,6 +253,8 @@ account-lookup-service:
       ${indent(8, account_lookup_admin_service_affinity)}
 # %{ endif }
     tolerations: *MOJALOOP_TOLERATIONS
+    podLabels:
+      sidecar.istio.io/inject: "${enable_istio_injection}"
     replicaCount: 1 # timeout handler is designed to run as a single instance
     config: *ALS_CONFIG
     ingress:


### PR DESCRIPTION
As timeout handler needs to send error callbacks now, it needs https request mutation to be able to communicate using mTLS. **_infitx/CSI-1346_**