### PR TITLE
fix: update promtail configuration to use common var

### DIFF
--- a/terraform/gitops/generate-files/templates/monitoring/install/values-loki.yaml.tpl
+++ b/terraform/gitops/generate-files/templates/monitoring/install/values-loki.yaml.tpl
@@ -226,5 +226,11 @@ promtail:
             - __meta_kubernetes_pod_annotation_kubernetes_io_config_hash
             - __meta_kubernetes_pod_container_name
             target_label: __path__
-  tolerations:  
+          - source_labels:
+              - __meta_kubernetes_pod_label_app_kubernetes_io_instance
+              - __meta_kubernetes_pod_label_instance
+            regex: ^;*([^;]+)(;.*)?$
+            action: replace
+            target_label: instance
+  tolerations:
     - operator: "Exists"

--- a/terraform/gitops/generate-files/templates/monitoring/install/values-loki.yaml.tpl
+++ b/terraform/gitops/generate-files/templates/monitoring/install/values-loki.yaml.tpl
@@ -166,8 +166,7 @@ promtail:
               firstline: '^\d{4}-\d{2}-\d{2}T\d{1,2}:\d{2}:\d{2}\.\d{3}|^{'
               max_wait_time: 3s
               max_lines: 128
-        kubernetes_sd_configs:
-          - role: pod
+        kubernetes_sd_configs: ${jsonencode(promtail_kubernetes_sd_configs)}
         relabel_configs:
           - source_labels:
               - __meta_kubernetes_pod_controller_name

--- a/terraform/gitops/k8s-cluster-config/monitoring.tf
+++ b/terraform/gitops/k8s-cluster-config/monitoring.tf
@@ -57,7 +57,7 @@ module "generate_monitoring_files" {
     alertmanager_enabled                   = try(var.common_var_map.alertmanager_enabled, false)
     alertmanager_slack_integration_enabled = try(var.common_var_map.alertmanager_slack_integration_enabled, false)
     alertmanager_jira_integration_enabled  = try(var.common_var_map.alertmanager_jira_integration_enabled, false)
-    promtail_kubernetes_sd_configs         = try(var.common_var_map.promtail_kubernetes_sd_configs, [{role = "node"}])
+    promtail_kubernetes_sd_configs         = try(var.common_var_map.promtail_kubernetes_sd_configs, [{role = "pod"}])
     ceph_loki_credentials_secret_name      = "ceph-loki-credentials-secret"
     ceph_api_url                           = var.ceph_api_url
     ceph_loki_bucket                       = local.ceph_loki_bucket

--- a/terraform/gitops/k8s-cluster-config/monitoring.tf
+++ b/terraform/gitops/k8s-cluster-config/monitoring.tf
@@ -57,6 +57,7 @@ module "generate_monitoring_files" {
     alertmanager_enabled                   = try(var.common_var_map.alertmanager_enabled, false)
     alertmanager_slack_integration_enabled = try(var.common_var_map.alertmanager_slack_integration_enabled, false)
     alertmanager_jira_integration_enabled  = try(var.common_var_map.alertmanager_jira_integration_enabled, false)
+    promtail_kubernetes_sd_configs         = try(var.common_var_map.promtail_kubernetes_sd_configs, [{role = "node"}])
     ceph_loki_credentials_secret_name      = "ceph-loki-credentials-secret"
     ceph_api_url                           = var.ceph_api_url
     ceph_loki_bucket                       = local.ceph_loki_bucket


### PR DESCRIPTION
This allows to configure promtail in the common-vars.yaml file, for example:
```yaml
promtail_kubernetes_sd_configs:
  - role: pod
    namespaces:
      names:
        - mojaloop
```
Sending only mojaloop logs leads to a substantial improvement of resource usage:
![image](https://github.com/user-attachments/assets/794186e2-1171-485e-a6b8-5aba466e46b4)
