### PR TITLE
feat: add custom metadata for PushSecret to work

### DIFF
--- a/terraform/gitops/pm4ml/tenancy_vault.tf
+++ b/terraform/gitops/pm4ml/tenancy_vault.tf
@@ -10,6 +10,11 @@ resource "vault_kv_secret_v2" "mcm_client" {
   mount        = var.kv_path
   name         = "${var.cluster_name}/${each.key}/mcmdev_client_secret"
   data_json    = jsonencode({ value = "dummy" })
+  custom_metadata {
+    data = {
+      managed-by = "external-secrets"
+    }
+  }
   disable_read = true
   lifecycle {
     ignore_changes  = [data_json]

--- a/terraform/gitops/proxy-pm4ml/tenancy_vault.tf
+++ b/terraform/gitops/proxy-pm4ml/tenancy_vault.tf
@@ -10,6 +10,11 @@ resource "vault_kv_secret_v2" "mcm_client_a" {
   mount        = var.kv_path
   name         = "${var.cluster_name}/${each.key}/mcm_client_secret_a"
   data_json    = jsonencode({ value = "dummy" })
+  custom_metadata {
+    data = {
+      managed-by = "external-secrets"
+    }
+  }
   disable_read = true
   lifecycle {
     ignore_changes  = [data_json]
@@ -22,6 +27,11 @@ resource "vault_kv_secret_v2" "mcm_client_b" {
   name         = "${var.cluster_name}/${each.key}/mcm_client_secret_b"
   disable_read = true
   data_json    = jsonencode({ value = "dummy" })
+  custom_metadata {
+    data = {
+      managed-by = "external-secrets"
+    }
+  }
   lifecycle {
     ignore_changes  = [data_json]
   }


### PR DESCRIPTION
Add the metadata required for the PushSecret to work
Ref: https://github.com/external-secrets/external-secrets/blob/593eb139990bc0deeb437dfffc8b4d46bcfeea4f/pkg/provider/vault/vault.go#L477