### PR TITLE
fix: avoid PVC space consumed by MySQL core dump

### DIFF
--- a/terraform/gitops/stateful-resources/templates/stateful-resources/percona/mysql/db-cluster.yaml.tpl
+++ b/terraform/gitops/stateful-resources/templates/stateful-resources/percona/mysql/db-cluster.yaml.tpl
@@ -104,6 +104,8 @@ spec:
         max_connections=${database_config.max_connections}
         innodb_buffer_pool_size=${database_config.innodb_buffer_pool_size}
         wsrep_auto_increment_control=OFF
+        coredumper=/tmp/mysql-core-dump
+        innodb_buffer_pool_in_core_file=OFF
 #      wsrep_debug=CLIENT
 #      wsrep_provider_options="gcache.size=1G; gcache.recover=yes"
 #      [sst]


### PR DESCRIPTION
- Set the core dump to happen in the /tmp folder instead of the PVC
- Reduce the size of the core dump