### PR TITLE
feat: protect from accidentally running the destroy job and declutter

### DIFF
--- a/terraform/gitlab/ci-templates/k8s-cluster/.gitlab-ci.yml
+++ b/terraform/gitlab/ci-templates/k8s-cluster/.gitlab-ci.yml
@@ -129,7 +129,8 @@ fmt:
     - !reference [.source, script]
     - terragrunt hclfmt -check -diff
     - terragrunt run-all fmt -check -diff -recursive || true
-  when: manual
+  rules:
+    - when: never
 
 init:
   stage: init
@@ -154,7 +155,8 @@ validate:
     - !reference [.source, script]
     - terragrunt run-all validate-inputs
     - terragrunt run-all validate
-  when: manual
+  rules:
+    - when: never
 
 build:
   extends: .terraform:build
@@ -163,7 +165,8 @@ build:
       aud: https://$VAULT_FQDN
   script:
     - !reference [.source, script]
-  when: manual
+  rules:
+    - when: never
 
 deploy-infra:
   extends: .terraform:deploy
@@ -237,7 +240,6 @@ destroy:
   rules:
     - if: $CI_COMMIT_BRANCH == $CI_DEFAULT_BRANCH && $CI_COMMIT_TITLE =~ /^destroy:.*/
       when: manual
-    - when: never
 
 refresh-deploy-infra:
   extends: .terraform:deploy
@@ -290,10 +292,6 @@ tf-refresh-deploy-infra:
     when: always
   rules:
     - if: $CI_COMMIT_BRANCH == $CI_DEFAULT_BRANCH && $CI_COMMIT_TITLE =~ /^tf_trigger.*/
-    - if: $CI_COMMIT_BRANCH == $CI_DEFAULT_BRANCH && $CI_COMMIT_TITLE == "update generated configs to project"
-      when: manual
-      allow_failure: true
-    - when: manual
 
 lint-apps:
   stage: deploy

--- a/terraform/gitlab/ci-templates/k8s-cluster/.gitlab-ci.yml
+++ b/terraform/gitlab/ci-templates/k8s-cluster/.gitlab-ci.yml
@@ -234,7 +234,10 @@ destroy:
     - if [ -d "$ANSIBLE_BASE_OUTPUT_DIR" ]; then echo "Inventory artifact exists"; else echo "Inventory artifact does not exist; Please rerun deploy-infra before destroy"; exit 1; fi
     - terragrunt run-all destroy --terragrunt-non-interactive -input=false
     - .gitlab/scripts/cleanapps.sh $CI_PROJECT_PATH $CI_SERVER_HOST $CI_COMMIT_REF_NAME $GITOPS_BUILD_OUTPUT_DIR $GITLAB_CI_PAT $ARGO_CD_ROOT_APP_PATH
-  when: manual
+  rules:
+    - if: $CI_COMMIT_BRANCH == $CI_DEFAULT_BRANCH && $CI_COMMIT_TITLE =~ /^destroy:.*/
+      when: manual
+    - when: never
 
 refresh-deploy-infra:
   extends: .terraform:deploy


### PR DESCRIPTION
- disable the unused jobs `fmt`, `validate` and `build`
- the `destroy` job is only available if the commit message is prefixed with `destroy:`
- remove the manual run for `auto-run-tf`
![image](https://github.com/user-attachments/assets/32dcf670-0b83-4b83-a19a-1fff21cd8a5f)
