### PR TITLE
fix: add kyverno lint ignore template for Role and RoleBinding

### DIFF
--- a/terraform/gitops/generate-files/templates/kyverno/lint.ignore.tpl
+++ b/terraform/gitops/generate-files/templates/kyverno/lint.ignore.tpl
@@ -1,0 +1,1 @@
+kyverno-Role*.yml


### PR DESCRIPTION
ignore kyverno Role and RoleBinding, which fail to lint due to bad name:
![image](https://github.com/user-attachments/assets/25fbdcbb-a618-438a-a09b-38b5860218ff)
