### PR TITLE
fix: add startup probe to allow time for Keycloak schema initialization

### DIFF
--- a/terraform/gitops/generate-files/templates/keycloak/post-config/keycloak-cr.yaml.tpl
+++ b/terraform/gitops/generate-files/templates/keycloak/post-config/keycloak-cr.yaml.tpl
@@ -48,3 +48,13 @@ spec:
                   name: ${ref_secret_name}
                   key: ${ref_secret_key}
 %{ endfor ~}
+            startupProbe:
+              httpGet:
+                path: /health/live
+                port: 8443
+                scheme: HTTPS
+              initialDelaySeconds: 20
+              timeoutSeconds: 1
+              periodSeconds: 2
+              successThreshold: 1
+              failureThreshold: 300


### PR DESCRIPTION
A recent test shows ~7 minute startup when initializing the schema, so we give it ~10 in this PR
![image](https://github.com/user-attachments/assets/32bec18e-5c94-436a-aa1d-ca3e60d27132)
