### PR TITLE
fix: update resource limits and add ArgoCD hooks for database initialization jobs

### DIFF
--- a/gitops/applications/overlays/rdbms_provider/dbaas/deploy-env-onboard/percona-xtradb-cluster.yaml
+++ b/gitops/applications/overlays/rdbms_provider/dbaas/deploy-env-onboard/percona-xtradb-cluster.yaml
@@ -24,7 +24,7 @@ spec:
         requests:
           memory: ${ARGOCD_ENV_mysql_requests_memory}
           cpu: ${ARGOCD_ENV_mysql_requests_cpu}
-        limit:
+        limits:
           memory: ${ARGOCD_ENV_mysql_limits_memory}
           cpu: ${ARGOCD_ENV_mysql_limits_cpu}
       configuration: |

--- a/terraform/gitops/stateful-resources/templates/stateful-resources/monolith-db-init-job.yaml.tpl
+++ b/terraform/gitops/stateful-resources/templates/stateful-resources/monolith-db-init-job.yaml.tpl
@@ -4,6 +4,7 @@ metadata:
   name: init-job-${resource_name}
   namespace: ${stateful_resources_namespace}
   annotations:
+    argocd.argoproj.io/hook: PostSync
     argocd.argoproj.io/sync-wave: "-11"
 spec:
   template:

--- a/terraform/gitops/stateful-resources/templates/stateful-resources/percona/mysql/db-cluster.yaml.tpl
+++ b/terraform/gitops/stateful-resources/templates/stateful-resources/percona/mysql/db-cluster.yaml.tpl
@@ -780,6 +780,7 @@ metadata:
   name: init-${cluster_name}
   namespace: ${namespace}
   annotations:
+    argocd.argoproj.io/hook: PostSync
     argocd.argoproj.io/sync-wave: "-4"
 spec:
   template:

--- a/terraform/k8s/default-config/mojaloop-stateful-resources-ccdriven-databases.yaml
+++ b/terraform/k8s/default-config/mojaloop-stateful-resources-ccdriven-databases.yaml
@@ -10,8 +10,8 @@ common_platform_db:
     mysql_replicas: 1                                            # Number of MySQL replicas in the cluster
     mysql_requests_memory: "512Mi"                              # Memory request for MySQL pods
     mysql_requests_cpu: "300m"                                      # CPU request for MySQL pods
-    mysql_limits_memory: "4Gi"                                   # Memory limit for MySQL pods
-    mysql_limits_cpu: "2000m"                                        # CPU limit for MySQL pods
+    mysql_limits_memory: "16Gi"                                   # Memory limit for MySQL pods
+    mysql_limits_cpu: "16000m"                                        # CPU limit for MySQL pods
 
     # HAProxy specific configurations (for load balancing)
     haproxy_image: "percona/haproxy:2.8.11"                      # Docker image for the HAProxy instances


### PR DESCRIPTION
- fix typo, which caused limits to not be applied
- increase limits, to avoid MySQL performance issues
- add a hook for the init jobs to run when there are sync changes for the stateful resources app