### PR TITLE
feat: add a ceph object storage for audit logs

### DIFF
--- a/gitops/applications/base/deploy-env-onboard/env-buckets.yaml
+++ b/gitops/applications/base/deploy-env-onboard/env-buckets.yaml
@@ -106,3 +106,28 @@ spec:
       scK8sProviderName: ${ARGOCD_ENV_sc_provider_config_name}
       storageClassName: "ceph-bucket"
       maxSize: "${ARGOCD_ENV_percona_bucket_storage_size}"
+---
+apiVersion: objectstore.mojaloop.io/v1alpha1
+kind: ObjectStore
+metadata:
+  name: "${ARGOCD_ENV_env_name}-audit-bucket"
+  namespace: ${ARGOCD_ENV_env_name}
+spec:
+  parameters:
+    clusterName: ${ARGOCD_ENV_env_name}
+    objectStoreProvider: ${ARGOCD_ENV_object_storage_provider}
+    bucketName: "audit-${ARGOCD_ENV_env_name}-${ARGOCD_ENV_hyphenated_domain}"
+    namespace: ${ARGOCD_ENV_env_name}
+    ccK8sProviderName: "kubernetes-provider"
+    esoPushSecret: true
+    vaultSecretStore: "vault-secret-store"
+    vaultSecretPath: "${ARGOCD_ENV_env_name}/audit_bucket_access_key_id"
+    s3:
+      awsProviderName: "aws-cp-upbound-provider-config"
+      bucketRegion: ${ARGOCD_ENV_cloud_region}
+      forceDestroy: true
+      deletionPolicy: "Delete"
+    ceph:
+      scK8sProviderName: ${ARGOCD_ENV_sc_provider_config_name}
+      storageClassName: "ceph-bucket"
+      maxSize: "${ARGOCD_ENV_audit_bucket_storage_size}"

--- a/terraform/ccnew/ansible-k8s-deploy/templates/argoapps.yaml.tpl
+++ b/terraform/ccnew/ansible-k8s-deploy/templates/argoapps.yaml.tpl
@@ -526,6 +526,7 @@ argocd_override:
           cloud_region: "${cloud_region}"
           dns_zone_id: "${private_dns_zone_id}"
           velero_bucket_storage_size: "${velero_bucket_storage_size}"
+          audit_bucket_storage_size: "${audit_bucket_storage_size}"
         onboard_common_platform_db_rds_provider:
           rdbms_subnet_list: "${join(",", rdbms_subnet_list)}"
           rdbms_azs: "${join(",", rdbms_azs)}"

--- a/terraform/ccnew/default-config/common-vars.yaml
+++ b/terraform/ccnew/default-config/common-vars.yaml
@@ -505,3 +505,8 @@ cc_backup_bucket_storage_size: "30Gi"
 cc_backup_schedule: "0 * * * *"
 cc_backup_ttl: "24h0m0s"
 cc_backup_object_storage_provider: "s3"
+
+# audit
+audit_bucket_name: "control-center-audit-bucket"
+audit_bucket_max_objects: "'1000000'"
+audit_bucket_storage_size: "10Gi"

--- a/terraform/config-params/ccnew-config/env-onboard-config/bucket-secrets.tf
+++ b/terraform/config-params/ccnew-config/env-onboard-config/bucket-secrets.tf
@@ -127,3 +127,32 @@ resource "gitlab_project_variable" "bucket" {
   protected = false
   masked    = false
 }
+
+data "kubernetes_secret_v1" "audit_bucket" {
+  metadata {
+      name      = "audit-${var.env_name}-${var.hyphenated_domain}"
+      namespace = var.env_name
+  }
+}
+
+resource "vault_kv_secret_v2" "audit_bucket_access_key_id" {
+  mount               = var.kv_path
+  name                = "${var.env_name}/audit_bucket_access_key_id"
+  delete_all_versions = true
+  data_json = jsonencode(
+    {
+      value = try(data.kubernetes_secret_v1.audit_bucket.data.username, "")
+    }
+  )
+}
+
+resource "vault_kv_secret_v2" "audit_bucket_secret_key_id" {
+  mount               = var.kv_path
+  name                = "${var.env_name}/audit_bucket_secret_key_id"
+  delete_all_versions = true
+  data_json = jsonencode(
+    {
+      value = try(data.kubernetes_secret_v1.audit_bucket.data.password, "")
+    }
+  )
+}

--- a/terraform/gitops/k8s-cluster-config/stored-params.tf
+++ b/terraform/gitops/k8s-cluster-config/stored-params.tf
@@ -68,3 +68,8 @@ data "gitlab_project_variable" "object_store_percona_backup_bucket" {
   project = var.current_gitlab_project_id
   key     = "percona_bucket"
 }
+
+data "gitlab_project_variable" "object_store_audit_backup_bucket" {
+  project = var.current_gitlab_project_id
+  key     = "audit_bucket"
+}


### PR DESCRIPTION
This PR is only for adding a new ceph object storage bucket to store the audit logs.
This is not for adding the whole audit stack which is not finalised and agreed by mojaloop DA.