### PR TITLE
fix: add content security policy configuration to Grafana spec

### DIFF
--- a/terraform/gitops/generate-files/templates/monitoring/install/istio-vs.yaml.tpl
+++ b/terraform/gitops/generate-files/templates/monitoring/install/istio-vs.yaml.tpl
@@ -17,14 +17,6 @@ spec:
             host: grafana-service
             port:
               number: 3000
-          headers:
-            response:
-              add:
-                Content-Security-Policy: >-
-                  default-src 'self';
-                  script-src 'self' 'unsafe-inline';
-                  style-src 'self' 'unsafe-inline';
-                  img-src *.${cluster.domain};
 ---
 apiVersion: networking.istio.io/v1alpha3
 kind: VirtualService

--- a/terraform/gitops/generate-files/templates/monitoring/post-config/monitoring-crs.yaml.tpl
+++ b/terraform/gitops/generate-files/templates/monitoring/post-config/monitoring-crs.yaml.tpl
@@ -52,7 +52,7 @@ spec:
       use_refresh_token: "true"
       role_attribute_path: "contains(\"zitadel:grants\"[*], '${zitadel_project_id}:${grafana_admin_rbac_group}') && 'Admin' || contains(\"zitadel:grants\"[*], '${zitadel_project_id}:${grafana_user_rbac_group}') && 'Viewer'"
     security:
-      content_security_policy: true
+      content_security_policy: "true"
       content_security_policy_template: >-
         default-src 'self';
         script-src 'self' 'unsafe-eval' 'unsafe-inline' 'strict-dynamic' $NONCE;

--- a/terraform/gitops/generate-files/templates/monitoring/post-config/monitoring-crs.yaml.tpl
+++ b/terraform/gitops/generate-files/templates/monitoring/post-config/monitoring-crs.yaml.tpl
@@ -53,17 +53,7 @@ spec:
       role_attribute_path: "contains(\"zitadel:grants\"[*], '${zitadel_project_id}:${grafana_admin_rbac_group}') && 'Admin' || contains(\"zitadel:grants\"[*], '${zitadel_project_id}:${grafana_user_rbac_group}') && 'Viewer'"
     security:
       content_security_policy: "true"
-      content_security_policy_template: >-
-        "default-src 'self';
-        script-src 'self' 'unsafe-eval' 'unsafe-inline' 'strict-dynamic' $NONCE;
-        object-src 'none';
-        font-src 'self';
-        style-src 'self' 'unsafe-inline' blob:;
-        img-src 'self' *.${cluster.domain} data:;
-        base-uri 'self';
-        connect-src 'self' wss://$ROOT_PATH;
-        media-src 'none';
-        form-action 'self';"
+      content_security_policy_template: "\"\"\"default-src 'self';script-src 'self' 'unsafe-eval' 'unsafe-inline' 'strict-dynamic' $NONCE;object-src 'none';font-src 'self';style-src 'self' 'unsafe-inline' blob:;img-src 'self' *.drpp-onprem.global data:;base-uri 'self';connect-src 'self' wss://$ROOT_PATH;media-src 'none';form-action 'self';\"\"\""
 ---
 apiVersion: grafana.integreatly.org/v1beta1
 kind: GrafanaDatasource

--- a/terraform/gitops/generate-files/templates/monitoring/post-config/monitoring-crs.yaml.tpl
+++ b/terraform/gitops/generate-files/templates/monitoring/post-config/monitoring-crs.yaml.tpl
@@ -54,8 +54,7 @@ spec:
     security:
       content_security_policy: "true"
       content_security_policy_template: >-
-        "
-        default-src 'self';
+        "default-src 'self';
         script-src 'self' 'unsafe-eval' 'unsafe-inline' 'strict-dynamic' $NONCE;
         object-src 'none';
         font-src 'self';
@@ -64,8 +63,7 @@ spec:
         base-uri 'self';
         connect-src 'self' wss://$ROOT_PATH;
         media-src 'none';
-        form-action 'self';
-        "
+        form-action 'self';"
 ---
 apiVersion: grafana.integreatly.org/v1beta1
 kind: GrafanaDatasource

--- a/terraform/gitops/generate-files/templates/monitoring/post-config/monitoring-crs.yaml.tpl
+++ b/terraform/gitops/generate-files/templates/monitoring/post-config/monitoring-crs.yaml.tpl
@@ -53,7 +53,17 @@ spec:
       role_attribute_path: "contains(\"zitadel:grants\"[*], '${zitadel_project_id}:${grafana_admin_rbac_group}') && 'Admin' || contains(\"zitadel:grants\"[*], '${zitadel_project_id}:${grafana_user_rbac_group}') && 'Viewer'"
     security:
       content_security_policy: true
-      content_security_policy_template: script-src 'self' 'unsafe-eval' 'unsafe-inline' 'strict-dynamic' $NONCE;object-src 'none';font-src 'self';style-src 'self' 'unsafe-inline' blob:;img-src * data:;base-uri 'self';connect-src 'self' grafana.com ws://$ROOT_PATH wss://$ROOT_PATH;manifest-src 'self';media-src 'none';form-action 'self';
+      content_security_policy_template: >-
+        default-src 'self';
+        script-src 'self' 'unsafe-eval' 'unsafe-inline' 'strict-dynamic' $NONCE;
+        object-src 'none';
+        font-src 'self';
+        style-src 'self' 'unsafe-inline' blob:;
+        img-src 'self' *.${cluster.domain} data:;
+        base-uri 'self';
+        connect-src 'self' wss://$ROOT_PATH;
+        media-src 'none';
+        form-action 'self';
 ---
 apiVersion: grafana.integreatly.org/v1beta1
 kind: GrafanaDatasource

--- a/terraform/gitops/generate-files/templates/monitoring/post-config/monitoring-crs.yaml.tpl
+++ b/terraform/gitops/generate-files/templates/monitoring/post-config/monitoring-crs.yaml.tpl
@@ -54,6 +54,7 @@ spec:
     security:
       content_security_policy: "true"
       content_security_policy_template: >-
+        "
         default-src 'self';
         script-src 'self' 'unsafe-eval' 'unsafe-inline' 'strict-dynamic' $NONCE;
         object-src 'none';
@@ -64,6 +65,7 @@ spec:
         connect-src 'self' wss://$ROOT_PATH;
         media-src 'none';
         form-action 'self';
+        "
 ---
 apiVersion: grafana.integreatly.org/v1beta1
 kind: GrafanaDatasource

--- a/terraform/gitops/generate-files/templates/monitoring/post-config/monitoring-crs.yaml.tpl
+++ b/terraform/gitops/generate-files/templates/monitoring/post-config/monitoring-crs.yaml.tpl
@@ -51,6 +51,9 @@ spec:
       use_pkce: "true"
       use_refresh_token: "true"
       role_attribute_path: "contains(\"zitadel:grants\"[*], '${zitadel_project_id}:${grafana_admin_rbac_group}') && 'Admin' || contains(\"zitadel:grants\"[*], '${zitadel_project_id}:${grafana_user_rbac_group}') && 'Viewer'"
+    security:
+      content_security_policy: true
+      content_security_policy_template: script-src 'self' 'unsafe-eval' 'unsafe-inline' 'strict-dynamic' $NONCE;object-src 'none';font-src 'self';style-src 'self' 'unsafe-inline' blob:;img-src * data:;base-uri 'self';connect-src 'self' grafana.com ws://$ROOT_PATH wss://$ROOT_PATH;manifest-src 'self';media-src 'none';form-action 'self';
 ---
 apiVersion: grafana.integreatly.org/v1beta1
 kind: GrafanaDatasource

--- a/terraform/k8s/default-config/common-vars.yaml
+++ b/terraform/k8s/default-config/common-vars.yaml
@@ -28,7 +28,7 @@ prometheus_operator_version: 8.22.8
 prometheus_process_exporter_version: 0.4.2
 process_exporter_enabled: false
 grafana_operator_version: 3.5.11
-grafana_version: 11.6.1
+grafana_version: 12.1.0
 grafana_dashboard_tag: v16.3.0-snapshot.24 # TODO: update once v16.1.x is published
 tempo_chart_version: 3.8.4
 loki_chart_version: 2.13.0


### PR DESCRIPTION
Upgrade to recent Grafana and configure CSP per https://grafana.com/docs/grafana/latest/setup-grafana/configure-security/configure-security-hardening/#add-a-content-security-policy

Closes mojaloop/project#4236