### PR TITLE
feat: improve configuration merging for pm4ml and addons

### DIFF
--- a/terraform/gitlab/ci-templates/k8s-cluster/.gitlab/scripts/config-merge.sh
+++ b/terraform/gitlab/ci-templates/k8s-cluster/.gitlab/scripts/config-merge.sh
@@ -7,7 +7,7 @@ ENV_TYPE=${ENV_TYPE:-dev}
 mkdir -p $CONFIG_PATH
 for configFile in $({ ls default-config/; ls custom-config/; } | sort -u)
 do
-    echo $configFile
+    echo -n $configFile " ➡️ "
     ENV_CONFIG=${configFile/%.yaml/.$ENV_TYPE.yaml}
     ENV_CONFIG=${ENV_CONFIG/%.json/.$ENV_TYPE.json}
     ADDON_CONFIG=${configFile/%.yaml/.config.yaml}
@@ -24,7 +24,7 @@ do
     # profiles/**/xxx-*.<env>.(yaml|json) sorted by name
     # custom-config/*.(yaml|json)
     # custom-config/xxx-*.(yaml|json) sorted by name
-    echo \
+    python3 .gitlab/scripts/dictmerge.py \
         default-config/$configFile \
         addons/**/@($ADDON_CONFIG) \
         addons/**/+(*-)@($ADDON_CONFIG) \

--- a/terraform/gitlab/ci-templates/k8s-cluster/.gitlab/scripts/config-merge.sh
+++ b/terraform/gitlab/ci-templates/k8s-cluster/.gitlab/scripts/config-merge.sh
@@ -8,23 +8,32 @@ mkdir -p $CONFIG_PATH
 for configFile in $({ ls default-config/; ls custom-config/; } | sort -u)
 do
     echo $configFile
-    YAML_ENV_CONFIG=${configFile/%.yaml/.$ENV_TYPE.yaml}
-    JSON_ENV_CONFIG=${configFile/%.json/.$ENV_TYPE.json}
-    python3 .gitlab/scripts/dictmerge.py \
+    ENV_CONFIG=${configFile/%.yaml/.$ENV_TYPE.yaml}
+    ENV_CONFIG=${ENV_CONFIG/%.json/.$ENV_TYPE.json}
+    ADDON_CONFIG=${configFile/%.yaml/.config.yaml}
+    ADDON_CONFIG=${ADDON_CONFIG/%.json/.config.json}
+    # merge configurations in the following order (later files override earlier ones):
+    # default-config/*.(yaml|json)
+    # addons/**/*.config.(yaml|json)
+    # addons/**/xxx-*.config.(yaml|json) sorted by name
+    # addons/**/*.<env>.(yaml|json)
+    # addons/**/xxx-*.<env>.(yaml|json) sorted by name
+    # profiles/**/*.(yaml|json)
+    # profiles/**/xxx-*.(yaml|json) sorted by name
+    # profiles/**/*.<env>.(yaml|json)
+    # profiles/**/xxx-*.<env>.(yaml|json) sorted by name
+    # custom-config/*.(yaml|json)
+    # custom-config/xxx-*.(yaml|json) sorted by name
+    echo \
         default-config/$configFile \
-        profiles/**/?(*-)$configFile \
-        profiles/**/?(*-)@($YAML_ENV_CONFIG|$JSON_ENV_CONFIG) \
+        addons/**/@($ADDON_CONFIG) \
+        addons/**/+(*-)@($ADDON_CONFIG) \
+        addons/**/@($ENV_CONFIG) \
+        addons/**/+(*-)@($ENV_CONFIG) \
+        profiles/**/$configFile \
+        profiles/**/+(*-)$configFile \
+        profiles/**/@($ENV_CONFIG) \
+        profiles/**/+(*-)@($ENV_CONFIG) \
         custom-config/$configFile \
         custom-config/+(*-)$configFile $CONFIG_PATH;
 done;
-
-# for configFile in {'mojaloop-stateful-resources.json','common-stateful-resources.json','mojaloop-rbac-api-resources.yaml'};
-# do
-#     if [ -f custom-config/$configFile ]; then
-#             cp custom-config/$configFile $CONFIG_PATH
-#             echo "custom-config/$configFile copied to $CONFIG_PATH"
-#     else
-#             cp default-config/$configFile $CONFIG_PATH
-#             echo "default-config/$configFile copied to $CONFIG_PATH"
-#      fi;
-# done;

--- a/terraform/gitlab/ci-templates/k8s-cluster/.gitlab/scripts/config-merge.sh
+++ b/terraform/gitlab/ci-templates/k8s-cluster/.gitlab/scripts/config-merge.sh
@@ -7,6 +7,7 @@ ENV_TYPE=${ENV_TYPE:-dev}
 mkdir -p $CONFIG_PATH
 for configFile in $({ ls default-config/; ls custom-config/; } | sort -u)
 do
+    echo
     echo -n $configFile " ➡️ "
     ENV_CONFIG=${configFile/%.yaml/.$ENV_TYPE.yaml}
     ENV_CONFIG=${ENV_CONFIG/%.json/.$ENV_TYPE.json}
@@ -37,3 +38,4 @@ do
         custom-config/$configFile \
         custom-config/+(*-)$configFile $CONFIG_PATH;
 done;
+echo

--- a/terraform/gitlab/ci-templates/k8s-cluster/.gitlab/scripts/dictmerge.py
+++ b/terraform/gitlab/ci-templates/k8s-cluster/.gitlab/scripts/dictmerge.py
@@ -123,11 +123,16 @@ if fileName in ( "common-stateful-resources.json" , "mojaloop-stateful-resources
         exit(1)
 else:
     merged = {}
-    if fileName == "pm4ml-vars.yaml" or fileName == "proxy-pm4ml-vars.yaml":
+    if fileName == "pm4ml-vars.yaml":
         for custom_config_file in custom_config_files:
             data2 = load_custom_config(custom_config_file)
-            if "default" in data2 and len(data2["default"]) > 0:
-                data1 = dict(mergedicts(data1, data2["default"]))
+            if "pm4mls_default" in data2 and len(data2["pm4mls_default"]) > 0:
+                data1 = dict(mergedicts(data1, data2["pm4mls_default"]))
+    elif fileName == "proxy-pm4ml-vars.yaml":
+        for custom_config_file in custom_config_files:
+            data2 = load_custom_config(custom_config_file)
+            if "proxy_pm4mls_default" in data2 and len(data2["proxy_pm4mls_default"]) > 0:
+                data1 = dict(mergedicts(data1, data2["proxy_pm4mls_default"]))
     for custom_config_file in custom_config_files:
         if fileName == "pm4ml-vars.yaml":
             data2 = load_custom_config(custom_config_file)

--- a/terraform/gitlab/ci-templates/k8s-cluster/.gitlab/scripts/dictmerge.py
+++ b/terraform/gitlab/ci-templates/k8s-cluster/.gitlab/scripts/dictmerge.py
@@ -123,6 +123,11 @@ if fileName in ( "common-stateful-resources.json" , "mojaloop-stateful-resources
         exit(1)
 else:
     merged = {}
+    if fileName == "pm4ml-vars.yaml" or fileName == "proxy-pm4ml-vars.yaml":
+        for custom_config_file in custom_config_files:
+            data2 = load_custom_config(custom_config_file)
+            if "default" in data2 and len(data2["default"]) > 0:
+                data1 = dict(mergedicts(data1, data2["default"]))
     for custom_config_file in custom_config_files:
         if fileName == "pm4ml-vars.yaml":
             data2 = load_custom_config(custom_config_file)

--- a/terraform/gitlab/ci-templates/k8s-cluster/.gitlab/scripts/dictmerge.py
+++ b/terraform/gitlab/ci-templates/k8s-cluster/.gitlab/scripts/dictmerge.py
@@ -91,6 +91,8 @@ if os.path.isfile(default_config_file):
 else:
     data1 = {}
 
+print(sys.argv)
+
 def load_custom_config(custom_config_file):
     customExt = os.path.splitext(custom_config_file)[1]
     if defaultExt != customExt:

--- a/terraform/gitlab/ci-templates/k8s-cluster/.gitlab/scripts/dictmerge.py
+++ b/terraform/gitlab/ci-templates/k8s-cluster/.gitlab/scripts/dictmerge.py
@@ -52,13 +52,13 @@ def mergeListOfDicts(data1, data2, fileName, outputFilename, fileType):
     mergedItems=[]
 
     if len(data2) == 0:
-        print("The custom-config file ",fileName, "is empty ,so using the default configuration file")
+        print("  The custom-config file ",fileName, "is empty ,so using the default configuration file")
         mergedItems = data1
         writeDict(mergedItems, fileType, outputFilename)
         exit(0)
 
     if len(data1) != len(data2):
-        print("The number of elements in custom-config and default_config differs for",fileName, ",so using the default configuration file")
+        print("  The number of elements in custom-config and default_config differs for",fileName, ",so using the default configuration file")
         mergedItems = data1
         writeDict(mergedItems, fileType, outputFilename)
         exit(0)
@@ -75,7 +75,7 @@ if len(sys.argv) >= 4:
     outputFilename = outputPath+"/"+fileName
     defaultExt = os.path.splitext(default_config_file)[1]
 else:
-    print("Please pass valid parameters usage : dictmerge.py defaultConfigFilePath ...customConfigFilePath outputPath")
+    print("  Please pass valid parameters usage : dictmerge.py defaultConfigFilePath ...customConfigFilePath outputPath")
     exit(1)
 
 if os.path.isfile(default_config_file):
@@ -86,7 +86,7 @@ if os.path.isfile(default_config_file):
         with open(default_config_file, 'r') as f:
             data1 = json.load(f)
     else:
-       print("File type not supported")
+       print("  File type not supported")
        exit(1)
 else:
     data1 = {}
@@ -96,7 +96,7 @@ print(sys.argv)
 def load_custom_config(custom_config_file):
     customExt = os.path.splitext(custom_config_file)[1]
     if defaultExt != customExt:
-        print("Please pass same type of files to merge")
+        print("  Please pass same type of files to merge")
         exit(1)
     if os.path.isfile(custom_config_file):
         if customExt == ".yaml":
@@ -107,21 +107,21 @@ def load_custom_config(custom_config_file):
                 with open(custom_config_file, 'r') as f:
                     return json.load(f)
             except json.JSONDecodeError:
-                print("Could not parse the custom config file", custom_config_file," so assigning empty dict")
+                print("  Could not parse the custom config file", custom_config_file," so assigning empty dict")
                 return {}
 
         else:
-            print("File type not supported:", custom_config_file)
+            print("  File type not supported:", custom_config_file)
             exit(1)
     else:
-        print("Custom config file "+custom_config_file+" file does not exist. Assigning empty data dict")
+        print("  Custom config file "+custom_config_file+" file does not exist. Assigning empty data dict")
         return {}
 
 if fileName in ( "common-stateful-resources.json" , "mojaloop-stateful-resources.json" , "mojaloop-rbac-api-resources.yaml","vnext-stateful-resources.json" ):
     if len(sys.argv) == 4:
         mergeListOfDicts(data1, load_custom_config(custom_config_files[0]), fileName, outputFilename, defaultExt)
     else:
-        print("Please pass valid parameters usage : dictmerge.py defaultConfigFilePath customConfigFilePath outputPath")
+        print("  Please pass valid parameters usage : dictmerge.py defaultConfigFilePath customConfigFilePath outputPath")
         exit(1)
 else:
     merged = {}


### PR DESCRIPTION
- fix merging of prefixed configs in the profiles to come after the unprefixed ones
- fix merging of the per environment configs in profiles, which had wrong logic for the extension replacement
- add support for configurations coming from the addons e.g. `*.config.yaml` and `*.<env>.yaml`
- allow default/common pm4ml settings to come from the profiles. This allows CD to be implemented for payment managers and inter-scheme proxies and reduce the overrides and the code duplication in the custom config.
- log the list of files being merged