### PR TITLE
feat: add report bucket configuration and secrets

### DIFF
--- a/gitops/applications/base/deploy-env-onboard/env-buckets.yaml
+++ b/gitops/applications/base/deploy-env-onboard/env-buckets.yaml
@@ -131,3 +131,28 @@ spec:
       scK8sProviderName: ${ARGOCD_ENV_sc_provider_config_name}
       storageClassName: "ceph-bucket"
       maxSize: "${ARGOCD_ENV_audit_bucket_storage_size}"
+---
+apiVersion: objectstore.mojaloop.io/v1alpha1
+kind: ObjectStore
+metadata:
+  name: "${ARGOCD_ENV_env_name}-report-bucket"
+  namespace: ${ARGOCD_ENV_env_name}
+spec:
+  parameters:
+    clusterName: ${ARGOCD_ENV_env_name}
+    objectStoreProvider: ${ARGOCD_ENV_object_storage_provider}
+    bucketName: "report-${ARGOCD_ENV_env_name}-${ARGOCD_ENV_hyphenated_domain}"
+    namespace: ${ARGOCD_ENV_env_name}
+    ccK8sProviderName: "kubernetes-provider"
+    esoPushSecret: true
+    vaultSecretStore: "vault-secret-store"
+    vaultSecretPath: "${ARGOCD_ENV_env_name}/report_bucket_access_key_id"
+    s3:
+      awsProviderName: "aws-cp-upbound-provider-config"
+      bucketRegion: ${ARGOCD_ENV_cloud_region}
+      forceDestroy: true
+      deletionPolicy: "Delete"
+    ceph:
+      scK8sProviderName: ${ARGOCD_ENV_sc_provider_config_name}
+      storageClassName: "ceph-bucket"
+      maxSize: "${ARGOCD_ENV_report_bucket_storage_size}"

--- a/terraform/ccnew/ansible-k8s-deploy/templates/argoapps.yaml.tpl
+++ b/terraform/ccnew/ansible-k8s-deploy/templates/argoapps.yaml.tpl
@@ -554,6 +554,7 @@ argocd_override:
           dbaas_default_management_policy: "${dbaas_default_management_policy}"
           velero_bucket_storage_size: "${velero_bucket_storage_size}"
           audit_bucket_storage_size: "${audit_bucket_storage_size}"
+          report_bucket_storage_size: "${report_bucket_storage_size}"
           tempo_bucket_storage_size: "${env_tempo_bucket_storage_size}"
           loki_bucket_storage_size: "${env_loki_bucket_storage_size}"
         onboard_common_platform_db_rds_provider:

--- a/terraform/ccnew/default-config/common-vars.yaml
+++ b/terraform/ccnew/default-config/common-vars.yaml
@@ -535,6 +535,11 @@ audit_bucket_name: "control-center-audit-bucket"
 audit_bucket_max_objects: "'1000000'"
 audit_bucket_storage_size: "10Gi"
 
+# report
+report_bucket_name: "control-center-report-bucket"
+report_bucket_max_objects: "'1000000'"
+report_bucket_storage_size: "10Gi"
+
 # env loki and tempo
 env_tempo_bucket_storage_size: "10Gi"
 env_loki_bucket_storage_size: "30Gi"

--- a/terraform/config-params/ccnew-config/env-onboard-config/bucket-secrets.tf
+++ b/terraform/config-params/ccnew-config/env-onboard-config/bucket-secrets.tf
@@ -156,3 +156,32 @@ resource "vault_kv_secret_v2" "audit_bucket_secret_key_id" {
     }
   )
 }
+
+data "kubernetes_secret_v1" "report_bucket" {
+  metadata {
+      name      = "report-${var.env_name}-${var.hyphenated_domain}"
+      namespace = var.env_name
+  }
+}
+
+resource "vault_kv_secret_v2" "report_bucket_access_key_id" {
+  mount               = var.kv_path
+  name                = "${var.env_name}/report_bucket_access_key_id"
+  delete_all_versions = true
+  data_json = jsonencode(
+    {
+      value = try(data.kubernetes_secret_v1.report_bucket.data.username, "")
+    }
+  )
+}
+
+resource "vault_kv_secret_v2" "report_bucket_secret_key_id" {
+  mount               = var.kv_path
+  name                = "${var.env_name}/report_bucket_secret_key_id"
+  delete_all_versions = true
+  data_json = jsonencode(
+    {
+      value = try(data.kubernetes_secret_v1.report_bucket.data.password, "")
+    }
+  )
+}

--- a/terraform/config-params/ccnew-config/env-onboard-config/variables.tf
+++ b/terraform/config-params/ccnew-config/env-onboard-config/variables.tf
@@ -155,5 +155,6 @@ locals {
     velero  = "velero"
     percona = "percona"
     audit   = "audit"
+    report   = "report"
   }
 }

--- a/terraform/gitops/k8s-cluster-config/stored-params.tf
+++ b/terraform/gitops/k8s-cluster-config/stored-params.tf
@@ -73,3 +73,8 @@ data "gitlab_project_variable" "object_store_audit_backup_bucket" {
   project = var.current_gitlab_project_id
   key     = "audit_bucket"
 }
+
+data "gitlab_project_variable" "object_store_report_backup_bucket" {
+  project = var.current_gitlab_project_id
+  key     = "report_bucket"
+}


### PR DESCRIPTION
This pull request introduces support for a new "report" object storage bucket across the infrastructure, similar to the existing "audit" bucket. The changes ensure that configuration, secrets management, and deployment templates all accommodate this new bucket type, making it easier to manage report data in a secure and consistent way.

**Report bucket integration:**

* Added a new `ObjectStore` resource definition for the report bucket in `env-buckets.yaml`, including provider parameters and secret management configuration.
* Introduced new variables for the report bucket (name, max objects, storage size) in `common-vars.yaml`, aligning with how audit bucket variables are handled.
* Added `report_bucket_storage_size` to the ArgoCD override configuration in `argoapps.yaml.tpl`, ensuring the value is passed to deployments.

**Secrets and access management:**

* Created new Terraform resources in `bucket-secrets.tf` to fetch report bucket credentials from Kubernetes and store them in Vault, mirroring the audit bucket approach.
* Updated local bucket type mappings to include "report" in `variables.tf`, supporting consistent referencing in code.

**CI/CD parameterization:**

* Added support for a `report_bucket` GitLab project variable in `stored-params.tf`, enabling dynamic configuration in CI/CD pipelines.