### PR TITLE
chore(csi-1869): bump redis operator to test

### DIFF
--- a/terraform/gitops/generate-files/templates/stateful-resources-operators/values-redis.yaml.tpl
+++ b/terraform/gitops/generate-files/templates/stateful-resources-operators/values-redis.yaml.tpl
@@ -1,2 +1,2 @@
 redisOperator:
-  imageTag: v0.20.1
+  imageTag: v0.22.1

--- a/terraform/k8s/default-config/stateful-resources-operators.yaml
+++ b/terraform/k8s/default-config/stateful-resources-operators.yaml
@@ -31,7 +31,7 @@ redis:
   helm_chart: redis-operator
   namespace: redis
   release_name: redis
-  helm_chart_version: 0.20.0
+  helm_chart_version: 0.22.1
   helm_chart_repo: https://ot-container-kit.github.io/helm-charts/
   helm_chart_values_file: values-redis.yaml
 # percona-postgresql:


### PR DESCRIPTION
This pull request updates the Redis Operator deployment to use the latest available version. The main changes include bumping both the Docker image tag and the Helm chart version to `v0.22.1`, ensuring our Kubernetes resources use the most recent features and fixes.

**Redis Operator version updates:**

* Updated the `imageTag` for the Redis Operator in `values-redis.yaml.tpl` from `v0.20.1` to `v0.22.1`.
* Updated the `helm_chart_version` for the Redis Operator in `stateful-resources-operators.yaml` from `0.20.0` to `0.22.1`.