### PR TITLE
feat: parameterize sdk env

### DIFF
--- a/terraform/gitops/generate-files/templates/pm4ml/values-pm4ml.yaml.tpl
+++ b/terraform/gitops/generate-files/templates/pm4ml/values-pm4ml.yaml.tpl
@@ -175,6 +175,8 @@ scheme-adapter:
 #%{ else}
       REQUEST_PROCESSING_TIMEOUT_SECONDS: 10
 #%{ endif}
+      ${indent(6, yamlencode(additional_ml_connector_config))}
+
 
 #%{ if enable_sdk_bulk_transaction_support}
   sdk-scheme-adapter-dom-evt-handler:

--- a/terraform/gitops/pm4ml/pm4ml.tf
+++ b/terraform/gitops/pm4ml/pm4ml.tf
@@ -98,6 +98,7 @@ module "generate_pm4ml_files" {
     cbs_mock_config                                 = each.value.cbs_mock_config
     payment_token_adapter_config                    = each.value.payment_token_adapter_config
     ui_custom_config                                = each.value.ui_custom_config
+    additional_ml_connector_config                  = each.value.additional_ml_connector_config
     pm4ml_istio_gateway_namespace                   = local.pm4ml_istio_gateway_namespaces[each.key]
     pm4ml_istio_wildcard_gateway_name               = local.pm4ml_istio_wildcard_gateway_names[each.key]
     pm4ml_istio_gateway_name                        = local.pm4ml_istio_gateway_names[each.key]

--- a/terraform/k8s/default-config/pm4ml-vars.yaml
+++ b/terraform/k8s/default-config/pm4ml-vars.yaml
@@ -23,3 +23,5 @@ payment_token_adapter_config: {
 }
 ui_custom_config:
   TITLE: Payment Manager
+additional_ml_connector_config:
+  TRACE_FLAGS: "01"


### PR DESCRIPTION
This pull request introduces support for passing additional environment variables **"per"** PM4ML deployment.

Configuration support for ML connector:

* Added an `additional_ml_connector_config` section to the default PM4ML configuration, allowing values like `TRACE_FLAGS` to be set in `pm4ml-vars.yaml`.
