### PR TITLE
chore: bump percona cluster for testing

### DIFF
--- a/terraform/k8s/default-config/mojaloop-stateful-resources-monolith-databases.yaml
+++ b/terraform/k8s/default-config/mojaloop-stateful-resources-monolith-databases.yaml
@@ -12,7 +12,7 @@ common_platform_db:
     management_policy: "*"
     cluster_name: "common-platform-db"                         # Name of the cluster
     cr_version: "1.17.0"                                       # Custom Resource version for the operator
-    pxc_image: "percona/percona-xtradb-cluster:8.4.3-3.1"      # Docker image for the PXC nodes
+    pxc_image: "percona/percona-xtradb-cluster:8.4.6-6"        # Docker image for the PXC nodes
     image_pull_policy: "IfNotPresent"                          # Image pull policy for the PXC nodes
     mysql_storage_size: "30Gi"                                 # Storage size for MySQL data
     mysql_replicas: 1                                          # Number of MySQL replicas in the cluster
@@ -151,7 +151,7 @@ common_mojaloop_db:
     management_policy: "*"
     cluster_name: "common-mojaloop-db"                           # Name of the cluster
     cr_version: "1.17.0"                                         # Custom Resource version for the operator
-    pxc_image: "percona/percona-xtradb-cluster:8.4.3-3.1"        # Docker image for the PXC nodes
+    pxc_image: "percona/percona-xtradb-cluster:8.4.6-6"          # Docker image for the PXC nodes
     mysql_storage_size: "30Gi"                                   # Storage size for MySQL data
     mysql_replicas: 1                                            # Number of MySQL replicas in the cluster
     mysql_requests_memory: "512Mi"                               # Memory request for MySQL pods


### PR DESCRIPTION
This pull request updates the Percona XtraDB Cluster (PXC) Docker image version used for both the `common_platform_db` and `common_mojaloop_db` clusters in the `mojaloop-stateful-resources-monolith-databases.yaml` configuration file. This change ensures both clusters use the latest available image, which likely includes important bug fixes and security updates.

Database image version upgrades:

* Updated the `pxc_image` for `common_platform_db` from `8.4.3-3.1` to `8.4.6-6` in `terraform/k8s/default-config/mojaloop-stateful-resources-monolith-databases.yaml`
* Updated the `pxc_image` for `common_mojaloop_db` from `8.4.3-3.1` to `8.4.6-6` in `terraform/k8s/default-config/mojaloop-stateful-resources-monolith-databases.yaml`