### PR TITLE
feat: add Content-Security-Policy headers to enhance security for admin portal

### DIFF
--- a/terraform/gitops/generate-files/templates/istio/istio-gateways/proxy-security-headers.yaml.tpl
+++ b/terraform/gitops/generate-files/templates/istio/istio-gateways/proxy-security-headers.yaml.tpl
@@ -40,7 +40,7 @@ spec:
                 end
               end
               if not response_handle:headers():get("Permissions-Policy") then
-                response_handle:headers():add("Permissions-Policy", "microphone=(), geolocation=(), camera=(), display-capture=()");
+                response_handle:headers():add("Permissions-Policy", "microphone=(), geolocation=(), camera=(), display-capture=(), payment=(), usb=()");
               end
               if not response_handle:headers():get("X-Frame-Options") then
                 response_handle:headers():add("X-Frame-Options", "deny");
@@ -68,9 +68,7 @@ spec:
                                               "camera 'none';"..
                                               "microphone 'none';"..
                                               "geolocation 'none';"..
-                                              "encrypted-media 'none';"..
                                               "payment 'none';"..
-                                              "speaker 'none';"..
                                               "usb 'none';");
               end
               if response_handle:headers():get("X-Powered-By") then
@@ -134,7 +132,7 @@ spec:
                 end
               end
               if not response_handle:headers():get("Permissions-Policy") then
-                response_handle:headers():add("Permissions-Policy", "microphone=(), geolocation=(), camera=(), display-capture=()");
+                response_handle:headers():add("Permissions-Policy", "microphone=(), geolocation=(), camera=(), display-capture=(), payment=(), usb=()");
               end
               if not response_handle:headers():get("X-Frame-Options") then
                 response_handle:headers():add("X-Frame-Options", "deny");
@@ -162,9 +160,7 @@ spec:
                                               "camera 'none';"..
                                               "microphone 'none';"..
                                               "geolocation 'none';"..
-                                              "encrypted-media 'none';"..
                                               "payment 'none';"..
-                                              "speaker 'none';"..
                                               "usb 'none';");
               end
               if response_handle:headers():get("X-Powered-By") then

--- a/terraform/gitops/generate-files/templates/istio/istio-gateways/proxy-security-headers.yaml.tpl
+++ b/terraform/gitops/generate-files/templates/istio/istio-gateways/proxy-security-headers.yaml.tpl
@@ -39,6 +39,9 @@ spec:
                   response_handle:headers():replace("Content-Security-Policy", csp);
                 end
               end
+              if not response_handle:headers():get("Permissions-Policy") then
+                response_handle:headers():add("Permissions-Policy", "microphone=(), geolocation=(), camera=(), display-capture=()");
+              end
               if not response_handle:headers():get("X-Frame-Options") then
                 response_handle:headers():add("X-Frame-Options", "deny");
               end
@@ -129,6 +132,9 @@ spec:
                   csp = csp .. ";frame-ancestors none;";
                   response_handle:headers():replace("Content-Security-Policy", csp);
                 end
+              end
+              if not response_handle:headers():get("Permissions-Policy") then
+                response_handle:headers():add("Permissions-Policy", "microphone=(), geolocation=(), camera=(), display-capture=()");
               end
               if not response_handle:headers():get("X-Frame-Options") then
                 response_handle:headers():add("X-Frame-Options", "deny");

--- a/terraform/gitops/generate-files/templates/pm4ml/istio-gateway.yaml.tpl
+++ b/terraform/gitops/generate-files/templates/pm4ml/istio-gateway.yaml.tpl
@@ -52,6 +52,16 @@ spec:
             host: ${pm4ml_release_name}-frontend
             port:
               number: 80
+          headers:
+            response:
+              add:
+                Content-Security-Policy: >-
+                  default-src 'self';
+                  style-src 'self' 'unsafe-inline' https://fonts.googleapis.com;
+                  font-src 'self' https://fonts.gstatic.com;
+                  script-src 'self' 'unsafe-inline';
+                  connect-src 'self' ${auth_fqdn};
+                  img-src 'self' data:;
 ---
 apiVersion: networking.istio.io/v1alpha3
 kind: VirtualService
@@ -275,7 +285,6 @@ spec:
                   style-src 'self' 'unsafe-inline' https://use.fontawesome.com https://cdnjs.cloudflare.com https://stackpath.bootstrapcdn.com https://cdn.datatables.net;
                   script-src 'self' 'unsafe-inline' https://cdnjs.cloudflare.com https://cdn.datatables.net https://code.jquery.com;
                   font-src 'self' https://use.fontawesome.com;
-                  frame-ancestors 'self' *.${cluster.domain};
  - name: socket
       match:
         - uri:
@@ -301,6 +310,7 @@ spec:
                   default-src 'self';
                   style-src 'self' 'unsafe-inline';
                   connect-src 'self' https://api.github.com;
+                  frame-ancestors 'self' *.${cluster.domain};
 ---
 # %{ endif }
 # %{ if payment_token_adapter_config.enabled}

--- a/terraform/gitops/generate-files/templates/pm4ml/istio-gateway.yaml.tpl
+++ b/terraform/gitops/generate-files/templates/pm4ml/istio-gateway.yaml.tpl
@@ -60,8 +60,8 @@ spec:
                   style-src 'self' 'unsafe-inline' https://fonts.googleapis.com;
                   font-src 'self' https://fonts.gstatic.com;
                   script-src 'self' 'unsafe-inline';
-                  connect-src 'self' ${auth_fqdn};
-                  img-src 'self' data:;
+                  connect-src 'self' ${auth_fqdn} ${experience_api_fqdn};
+                  img-src 'self' data: https://img.icons8.com;
 ---
 apiVersion: networking.istio.io/v1alpha3
 kind: VirtualService
@@ -134,8 +134,8 @@ spec:
                   style-src 'self' 'unsafe-inline' https://fonts.googleapis.com;
                   font-src 'self' https://fonts.gstatic.com;
                   script-src 'self' 'unsafe-inline';
-                  connect-src 'self' ${auth_fqdn};
-                  img-src 'self' data:;
+                  connect-src 'self' ${auth_fqdn} ${experience_api_fqdn};
+                  img-src 'self' data: https://img.icons8.com;
 ---
 apiVersion: security.istio.io/v1beta1
 kind: AuthorizationPolicy

--- a/terraform/gitops/generate-files/templates/pm4ml/istio-gateway.yaml.tpl
+++ b/terraform/gitops/generate-files/templates/pm4ml/istio-gateway.yaml.tpl
@@ -285,7 +285,7 @@ spec:
                   style-src 'self' 'unsafe-inline' https://use.fontawesome.com https://cdnjs.cloudflare.com https://stackpath.bootstrapcdn.com https://cdn.datatables.net;
                   script-src 'self' 'unsafe-inline' https://cdnjs.cloudflare.com https://cdn.datatables.net https://code.jquery.com;
                   font-src 'self' https://use.fontawesome.com;
- - name: socket
+    - name: socket
       match:
         - uri:
             prefix: /socket.io/

--- a/terraform/gitops/generate-files/templates/pm4ml/istio-gateway.yaml.tpl
+++ b/terraform/gitops/generate-files/templates/pm4ml/istio-gateway.yaml.tpl
@@ -116,6 +116,16 @@ spec:
             host: ${admin_portal_release_name}-reporting-hub-bop-shell
             port:
               number: 80
+          headers:
+            response:
+              add:
+                Content-Security-Policy: >-
+                  default-src 'self';
+                  style-src 'self' 'unsafe-inline' https://fonts.googleapis.com;
+                  font-src 'self' https://fonts.gstatic.com;
+                  script-src 'self' 'unsafe-inline';
+                  connect-src 'self' ${auth_fqdn};
+                  img-src 'self' data:;
 ---
 apiVersion: security.istio.io/v1beta1
 kind: AuthorizationPolicy
@@ -265,7 +275,8 @@ spec:
                   style-src 'self' 'unsafe-inline' https://use.fontawesome.com https://cdnjs.cloudflare.com https://stackpath.bootstrapcdn.com https://cdn.datatables.net;
                   script-src 'self' 'unsafe-inline' https://cdnjs.cloudflare.com https://cdn.datatables.net https://code.jquery.com;
                   font-src 'self' https://use.fontawesome.com;
-    - name: socket
+                  frame-ancestors 'self' *.${cluster.domain};
+ - name: socket
       match:
         - uri:
             prefix: /socket.io/

--- a/terraform/gitops/pm4ml/pm4ml.tf
+++ b/terraform/gitops/pm4ml/pm4ml.tf
@@ -104,6 +104,7 @@ module "generate_pm4ml_files" {
     pm4ml_istio_gateway_name                        = local.pm4ml_istio_gateway_names[each.key]
     cluster_name                                    = var.cluster_name
     traces_endpoint                                 = var.traces_endpoint
+    cluster                                         = var.cluster
   }
 
   file_list       = [for f in fileset(local.pm4ml_template_path, "**/*.tpl") : trimsuffix(f, ".tpl") if !can(regex(local.pm4ml_app_file, f))]


### PR DESCRIPTION
**Security header enhancements:**

* Added the `Permissions-Policy` response header to restrict access to sensitive browser features such as microphone, geolocation, camera, display-capture, payment, and USB in `proxy-security-headers.yaml.tpl`. [[1]](diffhunk://#diff-f231ca5f06d8e9f8a1dbf6a45aa0f8ef045da8bfe42bedad471a0c789217cd8fR42-R44) [[2]](diffhunk://#diff-f231ca5f06d8e9f8a1dbf6a45aa0f8ef045da8bfe42bedad471a0c789217cd8fR134-R136)
* Removed unnecessary directives (`encrypted-media`, `speaker`) from the CSP to further tighten security in `proxy-security-headers.yaml.tpl`. [[1]](diffhunk://#diff-f231ca5f06d8e9f8a1dbf6a45aa0f8ef045da8bfe42bedad471a0c789217cd8fL68-L70) [[2]](diffhunk://#diff-f231ca5f06d8e9f8a1dbf6a45aa0f8ef045da8bfe42bedad471a0c789217cd8fL159-L161)

**Content-Security-Policy improvements:**

* Added explicit CSP headers to the `pm4ml` and `admin-portal-reporting-hub-bop-shell` Istio gateway configurations, specifying allowed sources for styles, fonts, scripts, connections, and images in `pm4ml/istio-gateway.yaml.tpl`. [[1]](diffhunk://#diff-3d6fbce78c0181d75a6dc5bfb5a54fbd585b2d6526e5a26ea9d46bb03c908a3cR55-R64) [[2]](diffhunk://#diff-3d6fbce78c0181d75a6dc5bfb5a54fbd585b2d6526e5a26ea9d46bb03c908a3cR129-R138)
* Updated the CSP to include `frame-ancestors 'self' *.${cluster.domain}` to restrict which domains can embed the application in an iframe in `pm4ml/istio-gateway.yaml.tpl`.

**Configuration update:**

* Passed the `cluster` variable to the `generate_pm4ml_files` module to support domain-based CSP settings in `pm4ml.tf`.