### PR TITLE
feat: add storage CA access role and external secret for report bucket

### DIFF
--- a/gitops/applications/overlays/cloud_provider/private-cloud/storage-provider/deploy-env-onboard/kustomization.yaml
+++ b/gitops/applications/overlays/cloud_provider/private-cloud/storage-provider/deploy-env-onboard/kustomization.yaml
@@ -5,3 +5,4 @@ resources:
   - push-storage-secrets-vault.yaml
   - netbird-env-policy-config-claim.yaml
   - percona-role.yaml
+  - storage-ca-access.yaml

--- a/gitops/applications/overlays/cloud_provider/private-cloud/storage-provider/deploy-env-onboard/storage-ca-access.yaml
+++ b/gitops/applications/overlays/cloud_provider/private-cloud/storage-provider/deploy-env-onboard/storage-ca-access.yaml
@@ -1,0 +1,24 @@
+apiVersion: kubernetes.crossplane.io/v1alpha2
+kind: Object
+metadata:
+  name: ${ARGOCD_ENV_env_name}-ca-access
+spec:
+  forProvider:
+    manifest:
+      apiVersion: rbac.authorization.k8s.io/v1
+      kind: RoleBinding
+      metadata:
+        name: ${ARGOCD_ENV_env_name}-ca-access
+        namespace: ${ARGOCD_ENV_storage_namespace}
+      roleRef:
+        apiGroup: rbac.authorization.k8s.io
+        kind: Role
+        name: ca-access
+      subjects:
+        - kind: ServiceAccount
+          name: ${ARGOCD_ENV_env_name}
+          namespace: ${ARGOCD_ENV_env_name}
+  managementPolicies:
+    - '*'
+  providerConfigRef:
+    name: sc-kubernetes-provider

--- a/gitops/applications/overlays/cloud_provider/private-cloud/storage-provider/storage/rbac.yaml
+++ b/gitops/applications/overlays/cloud_provider/private-cloud/storage-provider/storage/rbac.yaml
@@ -50,3 +50,17 @@ roleRef:
   kind: ClusterRole
   name: read-secrets-from-source-ns
   apiGroup: rbac.authorization.k8s.io
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: ca-access
+  namespace: ${ARGOCD_ENV_storage_namespace}
+rules:
+  - apiGroups: [""]
+    resources:
+      - secrets
+    verbs:
+      - get
+    resourceNames:
+      - selfsigned-ca-cert

--- a/terraform/gitops/generate-files/templates/mojaloop/kustomization.yaml.tpl
+++ b/terraform/gitops/generate-files/templates/mojaloop/kustomization.yaml.tpl
@@ -10,6 +10,7 @@ resources:
   - opentelemetry-instrumentation.yaml
   - rbac-api-resources.yaml
   - simulator-issuer.yaml
+  - report-bucket.yaml
 helmCharts:
 - name: mojaloop
   releaseName: ${mojaloop_release_name}

--- a/terraform/gitops/generate-files/templates/mojaloop/report-bucket.yaml.tpl
+++ b/terraform/gitops/generate-files/templates/mojaloop/report-bucket.yaml.tpl
@@ -40,6 +40,7 @@ spec:
     destination:
       namespace: ${mojaloop_namespace}
       name: object-storage-ca
+      secretType: kubernetes.io/tls
   providerConfigsRef:
     sourceK8sProviderName: sc-kubernetes-provider
     destinationK8sProviderName: kubernetes-provider

--- a/terraform/gitops/generate-files/templates/mojaloop/report-bucket.yaml.tpl
+++ b/terraform/gitops/generate-files/templates/mojaloop/report-bucket.yaml.tpl
@@ -1,0 +1,47 @@
+apiVersion: external-secrets.io/v1beta1
+kind: ExternalSecret
+metadata:
+  name: report-object-storage-credentials
+spec:
+  refreshInterval: 5m
+
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: tenant-vault-secret-store
+
+  target:
+    name: report-object-storage-credentials
+    creationPolicy: Owner
+
+  data:
+    - secretKey: AWS_ACCESS_KEY_ID
+      remoteRef:
+        conversionStrategy: Default
+        decodingStrategy: None
+        key: "${cluster.env}/report_bucket_access_key_id"
+        property: value
+    - secretKey: AWS_SECRET_ACCESS_KEY
+      remoteRef:
+        conversionStrategy: Default
+        decodingStrategy: None
+        key: "${cluster.env}/report_bucket_secret_key_id"
+        property: value
+---
+apiVersion: utils.mojaloop.io/v1alpha1
+kind: ObjectSyncer
+metadata:
+  name: object-storage-ca
+spec:
+  parameters:
+    objectType: Secret
+    source:
+      namespace: rook-ceph
+      name: selfsigned-ca-cert
+    destination:
+      namespace: ${mojaloop_namespace}
+      name: object-storage-ca
+  providerConfigsRef:
+    sourceK8sProviderName: sc-kubernetes-provider
+    destinationK8sProviderName: kubernetes-provider
+  managementPolicies:
+    - "*"


### PR DESCRIPTION
Improve Ceph object store access from the environments by making the credentials to access it and the self-signed CA available in the environments in the mojaloop namespace. This is achieved by:
- adding a new role `ca-access` in the storage cluster's `storage` namespace, which enables access to the secret holding the self-signed CA
- adding a new role binding for each environment's service account to the `ca-access` role
- adding an `ObjectSyncer`, which syncs object store's the self-signed CA secret from the storage cluster
- adding an `ExternalSecret`, which syncs the credentials to access the report bucket