### PR TITLE
feat: improve addon app handling and configuration

### DIFF
--- a/docs/addons.md
+++ b/docs/addons.md
@@ -18,10 +18,10 @@ See the diagram below for the meaning of each directory and file:
 |   ├──📁 addon-name-1
 |   |   ├──📁 app-1                  # k8s resources for app-1
 |   |   |   ├── 📁 .config           # app 1 configs folder
-|   |   |   |    ├── app-1.app.yaml  # ArgoCD Application definition for app-1
 |   |   |   |    ├── app-1.yaml      # app 1 configuration
-|   |   |   |    └── other-app.yaml  # other app configuration (use with care)
+|   |   |   |    └── other-app.yaml  # other app configuration (use for dependencies)
 |   |   |   ├── 📁 app-1-folder      # app 1 misc files (no templating)
+|   |   |   ├── app-1.app.yaml       # ArgoCD Application definition for app-1
 |   |   |   ├── kustomization.yaml
 |   |   |   ├── values-default.yaml  # default values for app-1
 |   |   |   ├── values-override.yaml # template for overrides

--- a/docs/addons.md
+++ b/docs/addons.md
@@ -18,8 +18,7 @@ See the diagram below for the meaning of each directory and file:
 |   ├──📁 addon-name-1
 |   |   ├──📁 app-yamls              # define apps for the root app
 |   |   |   ├── 📁 .config           # app 1 configs
-|   |   |   |    ├── app-1.yaml      # argocd app config for app 1
-|   |   |   |    └── app-2.yaml      # argocd app config for app 2
+|   |   |   |    ├── app-yamls.yaml  # argocd app config for all apps
 |   |   |   ├── app-1.yaml           # ArgoCD Application definition for app-1
 |   |   |   └── app-2.yaml           # ArgoCD Application definition for app-2
 |   |   ├──📁 app-1                  # k8s resources for app-1
@@ -116,6 +115,29 @@ Addons are configured using several files:
       tag: v1.0.0   # override the image tag
   version: 1.0.0    # override the chart version
   ```
+
+## Template variables
+
+The following template variables are available for use in the addon app templates:
+
+- `app`: contains the merged configuration for the app, including
+  default values from the addon and overrides from the environment.
+  It has the following keys by default:
+  - `enabled: false`: boolean to enable or disable the app.
+  - `name: <folder-name>`: the name of the app.
+  - `namespace: <folder-name>`: the namespace where the app will be deployed.
+  - `syncWave: 0`: the sync wave for the ArgoCD app.
+- `cluster`: contains cluster-wide configuration values.
+  It has the following keys by default:
+  - `gitlabProjectUrl`: the URL of the GitLab project.
+  - `env`: the environment name (e.g., dev, staging, prod).
+  - `domain`: the base domain for the environment.
+  - `domainSuffix`: the domain suffix for the environment.
+  - `cc`: the control center name
+  - `sc`: the storage cluster name
+  - `submoduleRevisions`: a map of git submodule names to their revisions.
+- `apps`: provides access to the merged configuration of all addon apps,
+  useful for inter-app dependencies.
 
 ## Reusable addons
 

--- a/docs/addons.md
+++ b/docs/addons.md
@@ -9,20 +9,16 @@ Addons are defined as subdirectories in the `addons` directory.
 Each subdirectory includes tha apps that are part of the addon.
 Each app contains template files for creating the k8s resources and
 optional sub-folders for any files used by the templates.
-A special `app-yamls` folder defines the ArgoCD Application definitions
-for each app in the addon.
+A special `.app.yaml` extension denotes the ArgoCD `kind: Application` resources,
+which are added to tha `apps/app-yamls` folder.
 See the diagram below for the meaning of each directory and file:
 
 ```text
 ├──📁 addons
 |   ├──📁 addon-name-1
-|   |   ├──📁 app-yamls              # define apps for the root app
-|   |   |   ├── 📁 .config           # app 1 configs
-|   |   |   |    ├── app-yamls.yaml  # argocd app config for all apps
-|   |   |   ├── app-1.yaml           # ArgoCD Application definition for app-1
-|   |   |   └── app-2.yaml           # ArgoCD Application definition for app-2
 |   |   ├──📁 app-1                  # k8s resources for app-1
 |   |   |   ├── 📁 .config           # app 1 configs folder
+|   |   |   |    ├── app-1.app.yaml  # ArgoCD Application definition for app-1
 |   |   |   |    ├── app-1.yaml      # app 1 configuration
 |   |   |   |    └── other-app.yaml  # other app configuration (use with care)
 |   |   |   ├── 📁 app-1-folder      # app 1 misc files (no templating)
@@ -33,7 +29,6 @@ See the diagram below for the meaning of each directory and file:
 |   |   |   └── ...
 |   |   └──📁 app-2                 # k8s resources for app-2
 |   └──📁 addon-name-2
-|       ├──📁 app-yamls             # define apps for the root app
 |       ├──📁 app-3                 # k8s resources for app-3
 |       ├──📁 app-4                 # k8s resources for app-2
 |       └──📁 ...
@@ -55,25 +50,15 @@ Addons are configured using several files:
   Examples:
 
   ```yaml
-  # addons/example-addon/app-yamls/.config/app-yamls.yaml
-  app-1:
-    enabled: true
-    syncWave: 0
-    namespace: app-1
-  app-2:
-    enabled: true
-    syncWave: 0
-    namespace: app-2
-  ```
-
-  ```yaml
   # addons/example-addon/app-1/.config/app-1.yaml
+  enabled: true
   version: 2.7.0
   values: {}
   ```
 
   ```yaml
   # addons/example-addon/app-2/.config/app-2.yaml
+  enabled: true
   version: 0.7.26
   tag: v2.6.0
   values: {}
@@ -91,29 +76,23 @@ Addons are configured using several files:
       clientID: test
   ```
 
-- `custom-config/app-yamls.yaml`: environment overrides for ArgoCD app settings
-
-  Example:
-
-  ```yaml
-  # custom-config/app-yamls.yaml
-  app-1:
-    enabled: false              # disable app-1
-  app-2:
-    namespace: new-namespace    # change the namespace for app-2
-    syncWave: 1                 # move app-2 to sync wave 1
-  ```
-
 - `custom-config/<app-name>.yaml`: environment overrides for app-name
 
   Example:
 
   ```yaml
   # custom-config/app-1.yaml
+  enabled: false    # disable app-1
   values:           # chart values overrides
     image:
       tag: v1.0.0   # override the image tag
   version: 1.0.0    # override the chart version
+  ```
+
+  ```yaml
+  # custom-config/app-2.yaml
+  namespace: new-namespace    # change the namespace for app-2
+  syncWave: 1                 # move app-2 to sync wave 1
   ```
 
 ## Template variables

--- a/docs/addons.md
+++ b/docs/addons.md
@@ -9,23 +9,30 @@ Addons are defined as subdirectories in the `addons` directory.
 Each subdirectory includes tha apps that are part of the addon.
 Each app contains template files for creating the k8s resources and
 optional sub-folders for any files used by the templates.
+A special `app-yamls` folder defines the ArgoCD Application definitions
+for each app in the addon.
 See the diagram below for the meaning of each directory and file:
 
 ```text
 ├──📁 addons
 |   ├──📁 addon-name-1
 |   |   ├──📁 app-yamls              # define apps for the root app
-|   |   |   ├── app-1.yaml
-|   |   |   └── app-2.yaml
+|   |   |   ├── 📁 .config           # app 1 configs
+|   |   |   |    ├── app-1.yaml      # argocd app config for app 1
+|   |   |   |    └── app-2.yaml      # argocd app config for app 2
+|   |   |   ├── app-1.yaml           # ArgoCD Application definition for app-1
+|   |   |   └── app-2.yaml           # ArgoCD Application definition for app-2
 |   |   ├──📁 app-1                  # k8s resources for app-1
-|   |   |   ├── 📁 app-1-folder      # app 1 files
+|   |   |   ├── 📁 .config           # app 1 configs folder
+|   |   |   |    ├── app-1.yaml      # app 1 configuration
+|   |   |   |    └── other-app.yaml  # other app configuration (use with care)
+|   |   |   ├── 📁 app-1-folder      # app 1 misc files (no templating)
 |   |   |   ├── kustomization.yaml
 |   |   |   ├── values-default.yaml  # default values for app-1
 |   |   |   ├── values-override.yaml # template for overrides
 |   |   |   ├── vs.yaml              # virtual service for app-1
 |   |   |   └── ...
-|   |   ├──📁 app-2                 # k8s resources for app-2
-|   |   └── default.yaml            # default values for addon-name-1
+|   |   └──📁 app-2                 # k8s resources for app-2
 |   └──📁 addon-name-2
 |       ├──📁 app-yamls             # define apps for the root app
 |       ├──📁 app-3                 # k8s resources for app-3
@@ -43,29 +50,34 @@ See the diagram below for the meaning of each directory and file:
 
 Addons are configured using several files:
 
-- `addons/<addon-name>/default.yaml`: default values for the addon
+- `addons/<addon-name>/<app-name>/.config/<app-name>.yaml`: default values for
+  the app
 
-  Example:
+  Examples:
 
   ```yaml
-  app-yamls:
-      app-1:
-        enabled: true
-        syncWave: 0
-        namespace: app-1
-      app-2:
-        enabled: true
-        syncWave: 0
-        namespace: app-2
-
+  # addons/example-addon/app-yamls/.config/app-yamls.yaml
   app-1:
-      version: 2.7.0
-      values: {}
-
+    enabled: true
+    syncWave: 0
+    namespace: app-1
   app-2:
-      version: 0.7.26
-      tag: v2.6.0
-      values: {}
+    enabled: true
+    syncWave: 0
+    namespace: app-2
+  ```
+
+  ```yaml
+  # addons/example-addon/app-1/.config/app-1.yaml
+  version: 2.7.0
+  values: {}
+  ```
+
+  ```yaml
+  # addons/example-addon/app-2/.config/app-2.yaml
+  version: 0.7.26
+  tag: v2.6.0
+  values: {}
   ```
 
 - `addons/<addon-name>/<app-name>/values-default.yaml`: default values for each app
@@ -85,6 +97,7 @@ Addons are configured using several files:
   Example:
 
   ```yaml
+  # custom-config/app-yamls.yaml
   app-1:
     enabled: false              # disable app-1
   app-2:
@@ -97,6 +110,7 @@ Addons are configured using several files:
   Example:
 
   ```yaml
+  # custom-config/app-1.yaml
   values:           # chart values overrides
     image:
       tag: v1.0.0   # override the image tag
@@ -105,10 +119,15 @@ Addons are configured using several files:
 
 ## Reusable addons
 
-To achieve addons, profiles can be cloned as git submodules in the
-addons folder of the respective IAC environment repository.
+Addons are usually maintained in separate git repositories to allow reuse across
+multiple environments and projects. Each addon repository usually contains
+a group of related apps that are part of the addon. Examples of such addons are
+developer addons or security addons.
 
-The easiest way is to achieve that is to use the declarative
+To achieve reuse of addons, they can be cloned as git submodules in the
+addons folder of the respective environment repository.
+
+The easiest way to achieve that is to use the declarative
 approach and configure the addons in the `submodules.yaml`:
 
    ```yaml
@@ -120,5 +139,5 @@ approach and configure the addons in the `submodules.yaml`:
       ref: v1.0
    ```
 
-For more details check the [reusable profiles](profiles.md#reusable-profiles)
+For more details about this approach check the [reusable profiles](profiles.md#reusable-profiles)
 section in the profiles documentation.

--- a/terraform/gitlab/ci-templates/k8s-cluster/.gitlab/scripts/config-merge.sh
+++ b/terraform/gitlab/ci-templates/k8s-cluster/.gitlab/scripts/config-merge.sh
@@ -56,10 +56,10 @@ do
     # custom-config/xxx-*.(yaml|json) sorted by name
     python3 .gitlab/scripts/dictmerge.py \
         default-config/$configFile \
-        addons/@(${ENABLED_APPS_FOLDERS})/*/.config/$configFile \
-        addons/@(${ENABLED_APPS_FOLDERS})/*/.config/$ENV_CONFIG \
-        addons/@(${ENABLED_APPS_FOLDERS})/*/.config/+(*-)$configFile \
-        addons/@(${ENABLED_APPS_FOLDERS})/*/.config/+(*-)$ENV_CONFIG \
+        addons/*/@(${ENABLED_APPS_FOLDERS})/.config/$configFile \
+        addons/*/@(${ENABLED_APPS_FOLDERS})/.config/$ENV_CONFIG \
+        addons/*/@(${ENABLED_APPS_FOLDERS})/.config/+(*-)$configFile \
+        addons/*/@(${ENABLED_APPS_FOLDERS})/.config/+(*-)$ENV_CONFIG \
         profiles/**/$configFile \
         profiles/**/+(*-)$configFile \
         profiles/**/$ENV_CONFIG \

--- a/terraform/gitlab/ci-templates/k8s-cluster/.gitlab/scripts/config-merge.sh
+++ b/terraform/gitlab/ci-templates/k8s-cluster/.gitlab/scripts/config-merge.sh
@@ -5,7 +5,7 @@ shopt -s nullglob globstar extglob
 ENV_TYPE=${ENV_TYPE:-dev}
 
 mkdir -p $CONFIG_PATH
-for configFile in $({ ls default-config/; ls custom-config/; find addons -mindepth 2 -maxdepth 2 -type d -printf '%f.yaml\n'; } | sort -u)
+for configFile in $({ ls default-config/; ls custom-config/; find addons -mindepth 2 -maxdepth 2 -type d ! -name '.*' -printf '%f.yaml\n'; } | sort -u)
 do
     echo
     echo -n $configFile " ➡️ "

--- a/terraform/gitlab/ci-templates/k8s-cluster/.gitlab/scripts/config-merge.sh
+++ b/terraform/gitlab/ci-templates/k8s-cluster/.gitlab/scripts/config-merge.sh
@@ -21,7 +21,7 @@ python3 .gitlab/scripts/dictmerge.py \
     custom-config/+(*-)app-yamls.yaml $CONFIG_PATH;
 
 ENABLED_ADDONS=""
-for addon in $(find addons -mindepth 2 -maxdepth 2 -type d ! -name '.*'); do
+for addon in $(find addons -mindepth 2 -maxdepth 2 -type d ! -name '.*' -printf '%f '); do
     if [[ "$(yq eval ".${addon}Enabled // false" "$CONFIG_PATH/app-yamls.yaml")" == "true" || "$(yq eval ".${addon}.enabled // false" "$CONFIG_PATH/app-yamls.yaml")" == "true" ]]; then
         if [ -z "$ENABLED_ADDONS" ]; then
             ENABLED_ADDONS="${addon}.yaml"

--- a/terraform/gitlab/ci-templates/k8s-cluster/.gitlab/scripts/config-merge.sh
+++ b/terraform/gitlab/ci-templates/k8s-cluster/.gitlab/scripts/config-merge.sh
@@ -50,11 +50,7 @@ done;
 
 # Second pass to determine enabled addon apps and remove disabled app configs
 for app in $APPS; do
-    if [[
-        ( -f "$CONFIG_PATH/app-yamls.yaml" && "$(yq eval ".${app}Enabled // false" "$CONFIG_PATH/app-yamls.yaml")" == "true")
-        ||
-        ( -f "$CONFIG_PATH/${app}.yaml" && "$(yq eval ".enabled // false" "$CONFIG_PATH/${app}.yaml")" == "true" )
-    ]]; then
+    if [[ ( -f "$CONFIG_PATH/app-yamls.yaml" && "$(yq eval ".${app}Enabled // false" "$CONFIG_PATH/app-yamls.yaml")" == "true") || ( -f "$CONFIG_PATH/${app}.yaml" && "$(yq eval ".enabled // false" "$CONFIG_PATH/${app}.yaml")" == "true" ) ]]; then
         ENABLED_APPS="${ENABLED_APPS} ${app}.yaml"
     else
         # Remove config file for disabled apps

--- a/terraform/gitlab/ci-templates/k8s-cluster/.gitlab/scripts/config-merge.sh
+++ b/terraform/gitlab/ci-templates/k8s-cluster/.gitlab/scripts/config-merge.sh
@@ -5,8 +5,37 @@ shopt -s nullglob globstar extglob
 ENV_TYPE=${ENV_TYPE:-dev}
 
 mkdir -p $CONFIG_PATH
-for configFile in $({ ls default-config/; ls custom-config/; find addons -mindepth 2 -maxdepth 2 -type d ! -name '.*' -printf '%f.yaml\n'; } | sort -u)
+
+# Merge app-yamls first to determine enabled addons
+python3 .gitlab/scripts/dictmerge.py \
+    default-config/app-yamls.yaml \
+    addons/*/app-yamls/.config/app-yamls.yaml \
+    addons/*/app-yamls/.config/+(*-)app-yamls.yaml \
+    addons/*/app-yamls/.config/app-yamls.$ENV_TYPE.yaml \
+    addons/*/app-yamls/.config/+(*-)app-yamls.$ENV_TYPE.yaml \
+    profiles/**/app-yamls.yaml \
+    profiles/**/+(*-)app-yamls.yaml \
+    profiles/**/app-yamls.$ENV_TYPE.yaml \
+    profiles/**/+(*-)app-yamls.$ENV_TYPE.yaml \
+    custom-config/app-yamls.yaml \
+    custom-config/+(*-)app-yamls.yaml $CONFIG_PATH;
+
+ENABLED_ADDONS=""
+for addon in $(find addons -mindepth 2 -maxdepth 2 -type d ! -name '.*'); do
+    if [ "$(yq eval ".${addon}Enabled // false" "$CONFIG_PATH/app-yamls.yaml")" == "true" || "$(yq eval ".${addon}.enabled // false" "$CONFIG_PATH/app-yamls.yaml")" == "true" ]; then
+        if [ -z "$ENABLED_ADDONS" ]; then
+            ENABLED_ADDONS="${addon}.yaml"
+        else
+            ENABLED_ADDONS="${ENABLED_ADDONS} ${addon}.yaml"
+        fi
+    fi
+done
+echo -e "Enabled addons: $ENABLED_ADDONS"
+
+for configFile in $({ ls default-config/; ls custom-config/; echo $ENABLED_ADDONS; } | sort -u)
 do
+    # skip app-yamls
+    [[ "$configFile" == "app-yamls.yaml" ]] && continue
     echo
     echo -n $configFile " ➡️ "
     ENV_CONFIG=${configFile/%.yaml/.$ENV_TYPE.yaml}
@@ -25,14 +54,14 @@ do
     # custom-config/xxx-*.(yaml|json) sorted by name
     python3 .gitlab/scripts/dictmerge.py \
         default-config/$configFile \
-        addons/*/*/.config/$configFile \
-        addons/*/*/.config/+(*-)$configFile \
-        addons/*/*/.config/$ENV_CONFIG \
-        addons/*/*/.config/+(*-)$ENV_CONFIG \
+        addons/@(${ENABLED_ADDONS// /|})/*/.config/$configFile \
+        addons/@(${ENABLED_ADDONS// /|})/*/.config/+(*-)$configFile \
+        addons/@(${ENABLED_ADDONS// /|})/*/.config/$ENV_CONFIG \
+        addons/@(${ENABLED_ADDONS// /|})/*/.config/+(*-)$ENV_CONFIG \
         profiles/**/$configFile \
         profiles/**/+(*-)$configFile \
-        profiles/**/@($ENV_CONFIG) \
-        profiles/**/+(*-)@($ENV_CONFIG) \
+        profiles/**/$ENV_CONFIG \
+        profiles/**/+(*-)$ENV_CONFIG \
         custom-config/$configFile \
         custom-config/+(*-)$configFile $CONFIG_PATH;
 done;

--- a/terraform/gitlab/ci-templates/k8s-cluster/.gitlab/scripts/config-merge.sh
+++ b/terraform/gitlab/ci-templates/k8s-cluster/.gitlab/scripts/config-merge.sh
@@ -19,7 +19,7 @@ mkdir -p $CONFIG_PATH
 # custom-config/*.(yaml|json)
 # custom-config/xxx-*.(yaml|json) sorted by name
 
-APPS=$({find addons -mindepth 2 -maxdepth 2 -type d ! -name '.*' -printf '%f '; } | sort -u)
+APPS=$({ find addons -mindepth 2 -maxdepth 2 -type d ! -name '.*' -printf '%f '; } | sort -u)
 ENABLED_APPS=""
 
 # First pass to merge addon app configs

--- a/terraform/gitlab/ci-templates/k8s-cluster/.gitlab/scripts/config-merge.sh
+++ b/terraform/gitlab/ci-templates/k8s-cluster/.gitlab/scripts/config-merge.sh
@@ -25,6 +25,7 @@ ENABLED_APPS="app-yamls.yaml"
 # First pass to merge addon app configs
 echo ===============================================
 echo "Analyzing addon apps"
+echo ===============================================
 
 for app in $APPS; do
     echo
@@ -45,7 +46,11 @@ done;
 
 # Second pass to determine enabled addon apps and remove disabled app configs
 for app in $APPS; do
-    if [[ "$(yq eval ".${app}Enabled // false" "$CONFIG_PATH/app-yamls.yaml")" == "true" || "$(yq eval ".enabled // false" "$CONFIG_PATH/${app}.yaml")" == "true" ]]; then
+    if [[
+        ( -f "$CONFIG_PATH/app-yamls.yaml" && "$(yq eval ".${app}Enabled // false" "$CONFIG_PATH/app-yamls.yaml")" == "true")
+        ||
+        ( -f "$CONFIG_PATH/${app}.yaml" && "$(yq eval ".enabled // false" "$CONFIG_PATH/${app}.yaml")" == "true" )
+    ]]; then
         ENABLED_APPS="${ENABLED_APPS} ${app}.yaml"
     else
         # Remove config file for disabled apps
@@ -57,6 +62,7 @@ done
 
 echo ===============================================
 echo -e "Merging configuration, including enabled addon apps: $ENABLED_APPS"
+echo ===============================================
 ENABLED_APPS_FOLDERS="${ENABLED_APPS// /|}"
 ENABLED_APPS_FOLDERS="${ENABLED_APPS_FOLDERS//.yaml/}"
 

--- a/terraform/gitlab/ci-templates/k8s-cluster/.gitlab/scripts/config-merge.sh
+++ b/terraform/gitlab/ci-templates/k8s-cluster/.gitlab/scripts/config-merge.sh
@@ -20,19 +20,21 @@ python3 .gitlab/scripts/dictmerge.py \
     custom-config/app-yamls.yaml \
     custom-config/+(*-)app-yamls.yaml $CONFIG_PATH;
 
-ENABLED_ADDONS=""
+ENABLED_APPS=""
 for addon in $(find addons -mindepth 2 -maxdepth 2 -type d ! -name '.*' -printf '%f '); do
     if [[ "$(yq eval ".${addon}Enabled // false" "$CONFIG_PATH/app-yamls.yaml")" == "true" || "$(yq eval ".${addon}.enabled // false" "$CONFIG_PATH/app-yamls.yaml")" == "true" ]]; then
-        if [ -z "$ENABLED_ADDONS" ]; then
-            ENABLED_ADDONS="${addon}.yaml "
+        if [ -z "$ENABLED_APPS" ]; then
+            ENABLED_APPS="${addon}.yaml"
         else
-            ENABLED_ADDONS="${ENABLED_ADDONS}${addon}.yaml "
+            ENABLED_APPS="${ENABLED_APPS} ${addon}.yaml"
         fi
     fi
 done
-echo -e "Enabled addons: $ENABLED_ADDONS"
+echo -e "Enabled addon apps: $ENABLED_APPS"
+ENABLED_APPS_FOLDERS="${ENABLED_APPS// /|}"
+ENABLED_APPS_FOLDERS="${ENABLED_APPS_FOLDERS//.yaml/}"
 
-for configFile in $({ ls default-config/; ls custom-config/; echo $ENABLED_ADDONS; } | sort -u)
+for configFile in $({ ls default-config/; ls custom-config/; echo $ENABLED_APPS; } | sort -u)
 do
     # skip app-yamls
     [[ "$configFile" == "app-yamls.yaml" ]] && continue
@@ -54,10 +56,10 @@ do
     # custom-config/xxx-*.(yaml|json) sorted by name
     python3 .gitlab/scripts/dictmerge.py \
         default-config/$configFile \
-        addons/@(${ENABLED_ADDONS//.yaml /|})/*/.config/$configFile \
-        addons/@(${ENABLED_ADDONS//.yaml /|})/*/.config/$ENV_CONFIG \
-        addons/@(${ENABLED_ADDONS//.yaml /|})/*/.config/+(*-)$configFile \
-        addons/@(${ENABLED_ADDONS//.yaml /|})/*/.config/+(*-)$ENV_CONFIG \
+        addons/@(${ENABLED_APPS_FOLDERS})/*/.config/$configFile \
+        addons/@(${ENABLED_APPS_FOLDERS})/*/.config/$ENV_CONFIG \
+        addons/@(${ENABLED_APPS_FOLDERS})/*/.config/+(*-)$configFile \
+        addons/@(${ENABLED_APPS_FOLDERS})/*/.config/+(*-)$ENV_CONFIG \
         profiles/**/$configFile \
         profiles/**/+(*-)$configFile \
         profiles/**/$ENV_CONFIG \

--- a/terraform/gitlab/ci-templates/k8s-cluster/.gitlab/scripts/config-merge.sh
+++ b/terraform/gitlab/ci-templates/k8s-cluster/.gitlab/scripts/config-merge.sh
@@ -24,9 +24,9 @@ ENABLED_ADDONS=""
 for addon in $(find addons -mindepth 2 -maxdepth 2 -type d ! -name '.*' -printf '%f '); do
     if [[ "$(yq eval ".${addon}Enabled // false" "$CONFIG_PATH/app-yamls.yaml")" == "true" || "$(yq eval ".${addon}.enabled // false" "$CONFIG_PATH/app-yamls.yaml")" == "true" ]]; then
         if [ -z "$ENABLED_ADDONS" ]; then
-            ENABLED_ADDONS="${addon}.yaml"
+            ENABLED_ADDONS="${addon}.yaml "
         else
-            ENABLED_ADDONS="${ENABLED_ADDONS} ${addon}.yaml"
+            ENABLED_ADDONS="${ENABLED_ADDONS}${addon}.yaml "
         fi
     fi
 done
@@ -54,10 +54,10 @@ do
     # custom-config/xxx-*.(yaml|json) sorted by name
     python3 .gitlab/scripts/dictmerge.py \
         default-config/$configFile \
-        addons/@(${ENABLED_ADDONS// /|})/*/.config/$configFile \
-        addons/@(${ENABLED_ADDONS// /|})/*/.config/+(*-)$configFile \
-        addons/@(${ENABLED_ADDONS// /|})/*/.config/$ENV_CONFIG \
-        addons/@(${ENABLED_ADDONS// /|})/*/.config/+(*-)$ENV_CONFIG \
+        addons/@(${ENABLED_ADDONS// .yaml/|})/*/.config/$configFile \
+        addons/@(${ENABLED_ADDONS// .yaml/|})/*/.config/$ENV_CONFIG \
+        addons/@(${ENABLED_ADDONS// .yaml/|})/*/.config/+(*-)$configFile \
+        addons/@(${ENABLED_ADDONS// .yaml/|})/*/.config/+(*-)$ENV_CONFIG \
         profiles/**/$configFile \
         profiles/**/+(*-)$configFile \
         profiles/**/$ENV_CONFIG \

--- a/terraform/gitlab/ci-templates/k8s-cluster/.gitlab/scripts/config-merge.sh
+++ b/terraform/gitlab/ci-templates/k8s-cluster/.gitlab/scripts/config-merge.sh
@@ -19,7 +19,7 @@ mkdir -p $CONFIG_PATH
 # custom-config/*.(yaml|json)
 # custom-config/xxx-*.(yaml|json) sorted by name
 
-APPS=$({ find addons -mindepth 2 -maxdepth 2 -type d ! -name '.*' -printf '%f '; } | sort -u)
+APPS=$(find addons -mindepth 2 -maxdepth 2 -type d ! -name '.*' -printf '%f\n' | sort -u)
 ENABLED_APPS="app-yamls.yaml"
 
 # First pass to merge addon app configs

--- a/terraform/gitlab/ci-templates/k8s-cluster/.gitlab/scripts/config-merge.sh
+++ b/terraform/gitlab/ci-templates/k8s-cluster/.gitlab/scripts/config-merge.sh
@@ -13,10 +13,10 @@ do
     ENV_CONFIG=${ENV_CONFIG/%.json/.$ENV_TYPE.json}
     # merge configurations in the following order (later files override earlier ones):
     # default-config/*.(yaml|json)
-    # addons/*/.config/*.(yaml|json)
-    # addons/*/.config/xxx-*.(yaml|json) sorted by name
-    # addons/*/.config/*.<env>.(yaml|json)
-    # addons/*/.config/xxx-*.<env>.(yaml|json) sorted by name
+    # addons/*/*/.config/*.(yaml|json)
+    # addons/*/*/.config/xxx-*.(yaml|json) sorted by name
+    # addons/*/*/.config/*.<env>.(yaml|json)
+    # addons/*/*/.config/xxx-*.<env>.(yaml|json) sorted by name
     # profiles/**/*.(yaml|json)
     # profiles/**/xxx-*.(yaml|json) sorted by name
     # profiles/**/*.<env>.(yaml|json)
@@ -25,10 +25,10 @@ do
     # custom-config/xxx-*.(yaml|json) sorted by name
     python3 .gitlab/scripts/dictmerge.py \
         default-config/$configFile \
-        addons/*/.config/$configFile \
-        addons/*/.config/+(*-)$configFile \
-        addons/*/.config/$ENV_CONFIG \
-        addons/*/.config/+(*-)$ENV_CONFIG \
+        addons/*/*/.config/$configFile \
+        addons/*/*/.config/+(*-)$configFile \
+        addons/*/*/.config/$ENV_CONFIG \
+        addons/*/*/.config/+(*-)$ENV_CONFIG \
         profiles/**/$configFile \
         profiles/**/+(*-)$configFile \
         profiles/**/@($ENV_CONFIG) \

--- a/terraform/gitlab/ci-templates/k8s-cluster/.gitlab/scripts/config-merge.sh
+++ b/terraform/gitlab/ci-templates/k8s-cluster/.gitlab/scripts/config-merge.sh
@@ -44,7 +44,9 @@ for app in $APPS; do
         ENABLED_APPS="${ENABLED_APPS} ${app}.yaml"
     else
         # Remove config file for disabled apps
-        rm -f "$CONFIG_PATH/${app}.yaml"
+        if [ "${app}" != "app-yamls" && -f "$CONFIG_PATH/${app}.yaml" ]; then
+            rm -f "$CONFIG_PATH/${app}.yaml"
+        fi
     fi
 done
 

--- a/terraform/gitlab/ci-templates/k8s-cluster/.gitlab/scripts/config-merge.sh
+++ b/terraform/gitlab/ci-templates/k8s-cluster/.gitlab/scripts/config-merge.sh
@@ -6,7 +6,7 @@ ENV_TYPE=${ENV_TYPE:-dev}
 
 mkdir -p $CONFIG_PATH
 
-# Merge app-yamls first to determine enabled addons
+# Merge app-yamls first to determine enabled addon apps
 python3 .gitlab/scripts/dictmerge.py \
     default-config/app-yamls.yaml \
     addons/*/app-yamls/.config/app-yamls.yaml \
@@ -21,12 +21,12 @@ python3 .gitlab/scripts/dictmerge.py \
     custom-config/+(*-)app-yamls.yaml $CONFIG_PATH;
 
 ENABLED_APPS=""
-for addon in $(find addons -mindepth 2 -maxdepth 2 -type d ! -name '.*' -printf '%f '); do
-    if [[ "$(yq eval ".${addon}Enabled // false" "$CONFIG_PATH/app-yamls.yaml")" == "true" || "$(yq eval ".${addon}.enabled // false" "$CONFIG_PATH/app-yamls.yaml")" == "true" ]]; then
+for app in $(find addons -mindepth 2 -maxdepth 2 -type d ! -name '.*' -printf '%f '); do
+    if [[ "$(yq eval ".${app}Enabled // false" "$CONFIG_PATH/app-yamls.yaml")" == "true" || "$(yq eval ".${app}.enabled // false" "$CONFIG_PATH/app-yamls.yaml")" == "true" ]]; then
         if [ -z "$ENABLED_APPS" ]; then
-            ENABLED_APPS="${addon}.yaml"
+            ENABLED_APPS="${app}.yaml"
         else
-            ENABLED_APPS="${ENABLED_APPS} ${addon}.yaml"
+            ENABLED_APPS="${ENABLED_APPS} ${app}.yaml"
         fi
     fi
 done

--- a/terraform/gitlab/ci-templates/k8s-cluster/.gitlab/scripts/config-merge.sh
+++ b/terraform/gitlab/ci-templates/k8s-cluster/.gitlab/scripts/config-merge.sh
@@ -5,20 +5,18 @@ shopt -s nullglob globstar extglob
 ENV_TYPE=${ENV_TYPE:-dev}
 
 mkdir -p $CONFIG_PATH
-for configFile in $({ ls default-config/; ls custom-config/; } | sort -u)
+for configFile in $({ ls default-config/; ls custom-config/; find addons -mindepth 2 -maxdepth 2 -type d -printf '%f.yaml\n'; } | sort -u)
 do
     echo
     echo -n $configFile " ➡️ "
     ENV_CONFIG=${configFile/%.yaml/.$ENV_TYPE.yaml}
     ENV_CONFIG=${ENV_CONFIG/%.json/.$ENV_TYPE.json}
-    ADDON_CONFIG=${configFile/%.yaml/.config.yaml}
-    ADDON_CONFIG=${ADDON_CONFIG/%.json/.config.json}
     # merge configurations in the following order (later files override earlier ones):
     # default-config/*.(yaml|json)
-    # addons/**/*.config.(yaml|json)
-    # addons/**/xxx-*.config.(yaml|json) sorted by name
-    # addons/**/*.<env>.(yaml|json)
-    # addons/**/xxx-*.<env>.(yaml|json) sorted by name
+    # addons/*/.config/*.(yaml|json)
+    # addons/*/.config/xxx-*.(yaml|json) sorted by name
+    # addons/*/.config/*.<env>.(yaml|json)
+    # addons/*/.config/xxx-*.<env>.(yaml|json) sorted by name
     # profiles/**/*.(yaml|json)
     # profiles/**/xxx-*.(yaml|json) sorted by name
     # profiles/**/*.<env>.(yaml|json)
@@ -27,10 +25,10 @@ do
     # custom-config/xxx-*.(yaml|json) sorted by name
     python3 .gitlab/scripts/dictmerge.py \
         default-config/$configFile \
-        addons/**/@($ADDON_CONFIG) \
-        addons/**/+(*-)@($ADDON_CONFIG) \
-        addons/**/@($ENV_CONFIG) \
-        addons/**/+(*-)@($ENV_CONFIG) \
+        addons/*/.config/$configFile \
+        addons/*/.config/+(*-)$configFile \
+        addons/*/.config/$ENV_CONFIG \
+        addons/*/.config/+(*-)$ENV_CONFIG \
         profiles/**/$configFile \
         profiles/**/+(*-)$configFile \
         profiles/**/@($ENV_CONFIG) \

--- a/terraform/gitlab/ci-templates/k8s-cluster/.gitlab/scripts/config-merge.sh
+++ b/terraform/gitlab/ci-templates/k8s-cluster/.gitlab/scripts/config-merge.sh
@@ -31,17 +31,21 @@ for app in $APPS; do
     echo
     echo -n $app " 🔎 "
     python3 .gitlab/scripts/dictmerge.py \
-        default-config/${app}.yaml \
-        addons/*/${app}/.config/${app}.yaml \
-        addons/*/${app}/.config/+(*-)${app}.yaml \
-        addons/*/${app}/.config/${app}.$ENV_TYPE.yaml \
-        addons/*/${app}/.config/+(*-)${app}.$ENV_TYPE.yaml \
-        profiles/**/${app}.yaml \
-        profiles/**/+(*-)${app}.yaml \
-        profiles/**/${app}.$ENV_TYPE.yaml \
-        profiles/**/+(*-)${app}.$ENV_TYPE.yaml \
-        custom-config/${app}.yaml \
-        custom-config/+(*-)${app}.yaml $CONFIG_PATH;
+        default-config/$app.yaml \
+        addons/*/$app/.config/$app.yaml \
+        addons/*/$app/.config/+(*-)$app.yaml \
+        addons/*/$app/.config/$app.$ENV_TYPE.yaml \
+        addons/*/$app/.config/+(*-)$app.$ENV_TYPE.yaml \
+        addons/*/!($app)/.config/$app.yaml \
+        addons/*/!($app)/.config/+(*-)$app.yaml \
+        addons/*/!($app)/.config/$app.$ENV_TYPE.yaml \
+        addons/*/!($app)/.config/+(*-)$app.$ENV_TYPE.yaml \
+        profiles/**/$app.yaml \
+        profiles/**/+(*-)$app.yaml \
+        profiles/**/$app.$ENV_TYPE.yaml \
+        profiles/**/+(*-)$app.$ENV_TYPE.yaml \
+        custom-config/$app.yaml \
+        custom-config/+(*-)$app.yaml $CONFIG_PATH;
 done;
 
 # Second pass to determine enabled addon apps and remove disabled app configs

--- a/terraform/gitlab/ci-templates/k8s-cluster/.gitlab/scripts/config-merge.sh
+++ b/terraform/gitlab/ci-templates/k8s-cluster/.gitlab/scripts/config-merge.sh
@@ -23,7 +23,12 @@ APPS=$(find addons -mindepth 2 -maxdepth 2 -type d ! -name '.*' -printf '%f\n' |
 ENABLED_APPS="app-yamls.yaml"
 
 # First pass to merge addon app configs
+echo ===============================================
+echo "Analyzing addon apps"
+
 for app in $APPS; do
+    echo
+    echo -n $app " 🔎 "
     python3 .gitlab/scripts/dictmerge.py \
         default-config/${app}.yaml \
         addons/*/${app}/.config/${app}.yaml \
@@ -50,7 +55,8 @@ for app in $APPS; do
     fi
 done
 
-echo -e "Enabled addon apps: $ENABLED_APPS"
+echo ===============================================
+echo -e "Merging configuration, including enabled addon apps: $ENABLED_APPS"
 ENABLED_APPS_FOLDERS="${ENABLED_APPS// /|}"
 ENABLED_APPS_FOLDERS="${ENABLED_APPS_FOLDERS//.yaml/}"
 

--- a/terraform/gitlab/ci-templates/k8s-cluster/.gitlab/scripts/config-merge.sh
+++ b/terraform/gitlab/ci-templates/k8s-cluster/.gitlab/scripts/config-merge.sh
@@ -61,7 +61,7 @@ for app in $APPS; do
 done
 
 echo ===============================================
-echo -e "Merging configuration, including enabled addon apps: $ENABLED_APPS"
+echo -e "Merging configurations default, custom, profile and enabled addon apps: $ENABLED_APPS"
 echo ===============================================
 ENABLED_APPS_FOLDERS="${ENABLED_APPS// /|}"
 ENABLED_APPS_FOLDERS="${ENABLED_APPS_FOLDERS//.yaml/}"

--- a/terraform/gitlab/ci-templates/k8s-cluster/.gitlab/scripts/config-merge.sh
+++ b/terraform/gitlab/ci-templates/k8s-cluster/.gitlab/scripts/config-merge.sh
@@ -22,7 +22,7 @@ python3 .gitlab/scripts/dictmerge.py \
 
 ENABLED_ADDONS=""
 for addon in $(find addons -mindepth 2 -maxdepth 2 -type d ! -name '.*'); do
-    if [ "$(yq eval ".${addon}Enabled // false" "$CONFIG_PATH/app-yamls.yaml")" == "true" || "$(yq eval ".${addon}.enabled // false" "$CONFIG_PATH/app-yamls.yaml")" == "true" ]; then
+    if [[ "$(yq eval ".${addon}Enabled // false" "$CONFIG_PATH/app-yamls.yaml")" == "true" || "$(yq eval ".${addon}.enabled // false" "$CONFIG_PATH/app-yamls.yaml")" == "true" ]]; then
         if [ -z "$ENABLED_ADDONS" ]; then
             ENABLED_ADDONS="${addon}.yaml"
         else

--- a/terraform/gitlab/ci-templates/k8s-cluster/.gitlab/scripts/config-merge.sh
+++ b/terraform/gitlab/ci-templates/k8s-cluster/.gitlab/scripts/config-merge.sh
@@ -54,10 +54,10 @@ do
     # custom-config/xxx-*.(yaml|json) sorted by name
     python3 .gitlab/scripts/dictmerge.py \
         default-config/$configFile \
-        addons/@(${ENABLED_ADDONS// .yaml/|})/*/.config/$configFile \
-        addons/@(${ENABLED_ADDONS// .yaml/|})/*/.config/$ENV_CONFIG \
-        addons/@(${ENABLED_ADDONS// .yaml/|})/*/.config/+(*-)$configFile \
-        addons/@(${ENABLED_ADDONS// .yaml/|})/*/.config/+(*-)$ENV_CONFIG \
+        addons/@(${ENABLED_ADDONS//.yaml /|})/*/.config/$configFile \
+        addons/@(${ENABLED_ADDONS//.yaml /|})/*/.config/$ENV_CONFIG \
+        addons/@(${ENABLED_ADDONS//.yaml /|})/*/.config/+(*-)$configFile \
+        addons/@(${ENABLED_ADDONS//.yaml /|})/*/.config/+(*-)$ENV_CONFIG \
         profiles/**/$configFile \
         profiles/**/+(*-)$configFile \
         profiles/**/$ENV_CONFIG \

--- a/terraform/gitlab/ci-templates/k8s-cluster/.gitlab/scripts/config-merge.sh
+++ b/terraform/gitlab/ci-templates/k8s-cluster/.gitlab/scripts/config-merge.sh
@@ -6,34 +6,57 @@ ENV_TYPE=${ENV_TYPE:-dev}
 
 mkdir -p $CONFIG_PATH
 
-# Merge app-yamls first to determine enabled addon apps
-python3 .gitlab/scripts/dictmerge.py \
-    default-config/app-yamls.yaml \
-    addons/*/app-yamls/.config/app-yamls.yaml \
-    addons/*/app-yamls/.config/+(*-)app-yamls.yaml \
-    addons/*/app-yamls/.config/app-yamls.$ENV_TYPE.yaml \
-    addons/*/app-yamls/.config/+(*-)app-yamls.$ENV_TYPE.yaml \
-    profiles/**/app-yamls.yaml \
-    profiles/**/+(*-)app-yamls.yaml \
-    profiles/**/app-yamls.$ENV_TYPE.yaml \
-    profiles/**/+(*-)app-yamls.$ENV_TYPE.yaml \
-    custom-config/app-yamls.yaml \
-    custom-config/+(*-)app-yamls.yaml $CONFIG_PATH;
+# merge configurations in the following order (later files override earlier ones):
+# default-config/*.(yaml|json)
+# addons/*/*/.config/*.(yaml|json)
+# addons/*/*/.config/xxx-*.(yaml|json) sorted by name
+# addons/*/*/.config/*.<env>.(yaml|json)
+# addons/*/*/.config/xxx-*.<env>.(yaml|json) sorted by name
+# profiles/**/*.(yaml|json)
+# profiles/**/xxx-*.(yaml|json) sorted by name
+# profiles/**/*.<env>.(yaml|json)
+# profiles/**/xxx-*.<env>.(yaml|json) sorted by name
+# custom-config/*.(yaml|json)
+# custom-config/xxx-*.(yaml|json) sorted by name
 
+APPS=$({find addons -mindepth 2 -maxdepth 2 -type d ! -name '.*' -printf '%f '; } | sort -u)
 ENABLED_APPS=""
-for app in $(find addons -mindepth 2 -maxdepth 2 -type d ! -name '.*' -printf '%f '); do
-    if [[ "$(yq eval ".${app}Enabled // false" "$CONFIG_PATH/app-yamls.yaml")" == "true" || "$(yq eval ".${app}.enabled // false" "$CONFIG_PATH/app-yamls.yaml")" == "true" ]]; then
+
+# First pass to merge addon app configs
+for app in $APPS; do
+    python3 .gitlab/scripts/dictmerge.py \
+        default-config/${app}.yaml \
+        addons/*/${app}/.config/${app}.yaml \
+        addons/*/${app}/.config/+(*-)${app}.yaml \
+        addons/*/${app}/.config/${app}.$ENV_TYPE.yaml \
+        addons/*/${app}/.config/+(*-)${app}.$ENV_TYPE.yaml \
+        profiles/**/${app}.yaml \
+        profiles/**/+(*-)${app}.yaml \
+        profiles/**/${app}.$ENV_TYPE.yaml \
+        profiles/**/+(*-)${app}.$ENV_TYPE.yaml \
+        custom-config/${app}.yaml \
+        custom-config/+(*-)${app}.yaml $CONFIG_PATH;
+done;
+
+# Second pass to determine enabled addon apps and remove disabled app configs
+for app in $APPS; do
+    if [[ "$(yq eval ".${app}Enabled // false" "$CONFIG_PATH/app-yamls.yaml")" == "true" || "$(yq eval ".enabled // false" "$CONFIG_PATH/${app}.yaml")" == "true" ]]; then
         if [ -z "$ENABLED_APPS" ]; then
             ENABLED_APPS="${app}.yaml"
         else
             ENABLED_APPS="${ENABLED_APPS} ${app}.yaml"
         fi
+    else
+        # Remove config file for disabled apps
+        rm -f "$CONFIG_PATH/${app}.yaml"
     fi
 done
+
 echo -e "Enabled addon apps: $ENABLED_APPS"
 ENABLED_APPS_FOLDERS="${ENABLED_APPS// /|}"
 ENABLED_APPS_FOLDERS="${ENABLED_APPS_FOLDERS//.yaml/}"
 
+# Final pass to merge configs of enabled addon apps and other configs
 for configFile in $({ ls default-config/; ls custom-config/; echo $ENABLED_APPS; } | sort -u)
 do
     # skip app-yamls
@@ -42,18 +65,6 @@ do
     echo -n $configFile " ➡️ "
     ENV_CONFIG=${configFile/%.yaml/.$ENV_TYPE.yaml}
     ENV_CONFIG=${ENV_CONFIG/%.json/.$ENV_TYPE.json}
-    # merge configurations in the following order (later files override earlier ones):
-    # default-config/*.(yaml|json)
-    # addons/*/*/.config/*.(yaml|json)
-    # addons/*/*/.config/xxx-*.(yaml|json) sorted by name
-    # addons/*/*/.config/*.<env>.(yaml|json)
-    # addons/*/*/.config/xxx-*.<env>.(yaml|json) sorted by name
-    # profiles/**/*.(yaml|json)
-    # profiles/**/xxx-*.(yaml|json) sorted by name
-    # profiles/**/*.<env>.(yaml|json)
-    # profiles/**/xxx-*.<env>.(yaml|json) sorted by name
-    # custom-config/*.(yaml|json)
-    # custom-config/xxx-*.(yaml|json) sorted by name
     python3 .gitlab/scripts/dictmerge.py \
         default-config/$configFile \
         addons/*/@(${ENABLED_APPS_FOLDERS})/.config/$configFile \

--- a/terraform/gitlab/ci-templates/k8s-cluster/.gitlab/scripts/config-merge.sh
+++ b/terraform/gitlab/ci-templates/k8s-cluster/.gitlab/scripts/config-merge.sh
@@ -44,7 +44,7 @@ for app in $APPS; do
         ENABLED_APPS="${ENABLED_APPS} ${app}.yaml"
     else
         # Remove config file for disabled apps
-        if [ "${app}" != "app-yamls" && -f "$CONFIG_PATH/${app}.yaml" ]; then
+        if [[ "${app}" != "app-yamls" && -f "$CONFIG_PATH/${app}.yaml" ]]; then
             rm -f "$CONFIG_PATH/${app}.yaml"
         fi
     fi

--- a/terraform/gitlab/ci-templates/k8s-cluster/.gitlab/scripts/config-merge.sh
+++ b/terraform/gitlab/ci-templates/k8s-cluster/.gitlab/scripts/config-merge.sh
@@ -20,7 +20,7 @@ mkdir -p $CONFIG_PATH
 # custom-config/xxx-*.(yaml|json) sorted by name
 
 APPS=$({ find addons -mindepth 2 -maxdepth 2 -type d ! -name '.*' -printf '%f '; } | sort -u)
-ENABLED_APPS=""
+ENABLED_APPS="app-yamls.yaml"
 
 # First pass to merge addon app configs
 for app in $APPS; do
@@ -41,11 +41,7 @@ done;
 # Second pass to determine enabled addon apps and remove disabled app configs
 for app in $APPS; do
     if [[ "$(yq eval ".${app}Enabled // false" "$CONFIG_PATH/app-yamls.yaml")" == "true" || "$(yq eval ".enabled // false" "$CONFIG_PATH/${app}.yaml")" == "true" ]]; then
-        if [ -z "$ENABLED_APPS" ]; then
-            ENABLED_APPS="${app}.yaml"
-        else
-            ENABLED_APPS="${ENABLED_APPS} ${app}.yaml"
-        fi
+        ENABLED_APPS="${ENABLED_APPS} ${app}.yaml"
     else
         # Remove config file for disabled apps
         rm -f "$CONFIG_PATH/${app}.yaml"
@@ -59,8 +55,6 @@ ENABLED_APPS_FOLDERS="${ENABLED_APPS_FOLDERS//.yaml/}"
 # Final pass to merge configs of enabled addon apps and other configs
 for configFile in $({ ls default-config/; ls custom-config/; echo $ENABLED_APPS; } | sort -u)
 do
-    # skip app-yamls
-    [[ "$configFile" == "app-yamls.yaml" ]] && continue
     echo
     echo -n $configFile " ➡️ "
     ENV_CONFIG=${configFile/%.yaml/.$ENV_TYPE.yaml}

--- a/terraform/gitlab/ci-templates/k8s-cluster/.gitlab/scripts/dictmerge.py
+++ b/terraform/gitlab/ci-templates/k8s-cluster/.gitlab/scripts/dictmerge.py
@@ -158,7 +158,7 @@ else:
     if not merged:
         # if output file exists, remove it
         if os.path.isfile(outputFilename):
-            print("  Merged configuration is empty, removed existing output file:", outputFilename)
+            print("  Merged configuration is empty, removing existing output file:", outputFilename)
             os.remove(outputFilename)
         else:
             print("  Merged configuration is empty, not writing to output file.")

--- a/terraform/gitlab/ci-templates/k8s-cluster/.gitlab/scripts/dictmerge.py
+++ b/terraform/gitlab/ci-templates/k8s-cluster/.gitlab/scripts/dictmerge.py
@@ -154,6 +154,15 @@ else:
         else:
             data1 = dict(mergedicts(data1, load_custom_config(custom_config_file)))
             merged = data1
+    # if merged is empty object, don't write to file
+    if not merged:
+        # if output file exists, remove it
+        if os.path.isfile(outputFilename):
+            print("  Merged configuration is empty, removed existing output file:", outputFilename)
+            os.remove(outputFilename)
+        else:
+            print("  Merged configuration is empty, not writing to output file.")
+        exit(0)
     if defaultExt == ".yaml":
         #result = yaml.dump(dict(data1), indent=4, sort_keys=True)
         with open(outputFilename, 'w') as file:

--- a/terraform/gitlab/ci-templates/k8s-cluster/.gitlab/scripts/dictmerge.py
+++ b/terraform/gitlab/ci-templates/k8s-cluster/.gitlab/scripts/dictmerge.py
@@ -114,7 +114,6 @@ def load_custom_config(custom_config_file):
             print("  File type not supported:", custom_config_file)
             exit(1)
     else:
-        print("  Custom config file "+custom_config_file+" file does not exist. Assigning empty data dict")
         return {}
 
 if fileName in ( "common-stateful-resources.json" , "mojaloop-stateful-resources.json" , "mojaloop-rbac-api-resources.yaml","vnext-stateful-resources.json" ):
@@ -158,10 +157,7 @@ else:
     if not merged:
         # if output file exists, remove it
         if os.path.isfile(outputFilename):
-            print("  Merged configuration is empty, removing existing output file:", outputFilename)
             os.remove(outputFilename)
-        else:
-            print("  Merged configuration is empty, not writing to output file.")
         exit(0)
     if defaultExt == ".yaml":
         #result = yaml.dump(dict(data1), indent=4, sort_keys=True)

--- a/terraform/k8s/addons/generate-apps.tf
+++ b/terraform/k8s/addons/generate-apps.tf
@@ -5,14 +5,14 @@ resource "local_file" "config-file" {
     (
       split("/", filename)[1] == "app-yamls" ?
       coalesce(
-        try(local.override["${split("/", filename)[0]}/app-yamls"]["${split("/", trimsuffix(filename, ".yaml"))[2]}Enabled"], null),
-        try(local.override["${split("/", filename)[0]}/app-yamls"][split("/", trimsuffix(filename, ".yaml"))[2]].enabled, null),
-        try(local.default[split("/", filename)[0]]["app-yamls"]["${split("/", trimsuffix(filename, ".yaml"))[2]}Enabled"], false)
+        try(local.apps["app-yamls"]["${split("/", trimsuffix(filename, ".yaml"))[2]}Enabled"], null),
+        try(local.apps[split("/", filename)[1]].enabled, null),
+        try(local.addons[split("/", filename)[0]]["app-yamls"]["${split("/", trimsuffix(filename, ".yaml"))[2]}Enabled"], false)
       ) :
       coalesce(
-        try(local.override["${split("/", filename)[0]}/app-yamls"]["${split("/", filename)[1]}Enabled"], null),
-        try(local.override["${split("/", filename)[0]}/app-yamls"][split("/", filename)[1]].enabled, null),
-        try(local.default[split("/", filename)[0]]["app-yamls"]["${split("/", filename)[1]}Enabled"], false)
+        try(local.apps["app-yamls"]["${split("/", filename)[1]}Enabled"], null),
+        try(local.apps[split("/", filename)[1]].enabled, null),
+        try(local.addons[split("/", filename)[0]]["app-yamls"]["${split("/", filename)[1]}Enabled"], false)
       )
     )
   ]) # this represents addon-name/app-name/filename list of files filtered by enabled app-yamls
@@ -27,14 +27,15 @@ resource "local_file" "config-file" {
           enabled: false,
           syncWave: 0
         },
-        try(local.default[basename(dirname(dirname(each.key)))][basename(dirname(each.key))], {}),
-        local.override[dirname(each.key)],
+        try(local.addons[basename(dirname(dirname(each.key)))][basename(dirname(each.key))], {}),
+        local.apps[basename(dirname(each.key))],
         try(split("/", filename)[1] == "app-yamls" ? local.apps["app-yamls"][basename(trimsuffix(filename, ".yaml"))] : {}, {})
       )
+      apps: local.apps,
       filename: each.key
     }
   )
-  filename = "${var.outputDir}/${basename(dirname(each.key))}/${basename(each.key)}"
+  filename = "${var.outputDir}/${endswith(each.key, ".app.yaml") ? "app-yamls" : basename(dirname(each.key))}/${basename(each.key)}"
 }
 
 resource "local_file" "addon-file" {
@@ -44,14 +45,14 @@ resource "local_file" "addon-file" {
     (
       split("/", filename)[1] == "app-yamls" ?
       coalesce(
-        try(local.override["${split("/", filename)[0]}/app-yamls"]["${split("/", trimsuffix(filename, ".yaml"))[2]}Enabled"], null),
-        try(local.override["${split("/", filename)[0]}/app-yamls"][split("/", trimsuffix(filename, ".yaml"))[2]].enabled, null),
-        try(local.default[split("/", filename)[0]]["app-yamls"]["${split("/", trimsuffix(filename, ".yaml"))[2]}Enabled"], false)
+        try(local.apps["app-yamls"]["${split("/", trimsuffix(filename, ".yaml"))[2]}Enabled"], null),
+        try(local.apps[split("/", filename)[1]].enabled, null),
+        try(local.addons[split("/", filename)[0]]["app-yamls"]["${split("/", trimsuffix(filename, ".yaml"))[2]}Enabled"], false)
       ) :
       coalesce(
-        try(local.override["${split("/", filename)[0]}/app-yamls"]["${split("/", filename)[1]}Enabled"], null),
-        try(local.override["${split("/", filename)[0]}/app-yamls"][split("/", filename)[1]].enabled, null),
-        try(local.default[split("/", filename)[0]]["app-yamls"]["${split("/", filename)[1]}Enabled"], false)
+        try(local.apps["app-yamls"]["${split("/", filename)[1]}Enabled"], null),
+        try(local.apps[split("/", filename)[1]].enabled, null),
+        try(local.addons[split("/", filename)[0]]["app-yamls"]["${split("/", filename)[1]}Enabled"], false)
       )
     )
   ]) # this represents addon-name/app-name/folder-name/filename list of files filtered by enabled app-yamls
@@ -60,16 +61,13 @@ resource "local_file" "addon-file" {
 }
 
 locals {
-  default = { # load defaults for each addon, keyed by addon-name
+  addons = { # load defaults for each addon, keyed by addon-name
     for app in fileset(path.module, "*/default.yaml") :
     dirname(app) => yamldecode(templatefile(app, var.clusterConfig))
   }
-  override = { # load overrides for each app, keyed by addon-name/app-name
-    for app in distinct([for _, v in fileset(path.module, "*/*/*") : dirname(v)]) :
-    app => try(yamldecode(templatefile("${var.configPath}/${basename(app)}.yaml", merge(var.clusterConfig, { cluster: var.clusterConfig }))), {})
-  }
-  apps = {
-    for app_name, app_config in local.override : basename(app_name) => app_config
+  apps = { # load overrides for each app, keyed by app-name
+    for app in distinct([for _, v in fileset(path.module, "*/*/*") : basename(dirname(v))]) :
+    app => try(yamldecode(templatefile("${var.configPath}/${app}.yaml", merge(var.clusterConfig, { cluster: var.clusterConfig }))), {})
   }
 }
 

--- a/terraform/k8s/addons/generate-apps.tf
+++ b/terraform/k8s/addons/generate-apps.tf
@@ -28,7 +28,7 @@ resource "local_file" "config-file" {
           syncWave: 0
         },
         try(local.addons[basename(dirname(dirname(each.key)))][basename(dirname(each.key))], {}),
-        try(local.apps[endswith(each.key, ".app.yaml") ? trimsuffix(basename(each.key), ".app.yaml") : basename(dirname(each.key))], {}),
+        local.apps[basename(dirname(each.key))],
         try(split("/", each.key)[1] == "app-yamls" ? local.apps["app-yamls"][basename(trimsuffix(each.key, ".yaml"))] : {}, {})
       )
       apps: local.apps,

--- a/terraform/k8s/addons/generate-apps.tf
+++ b/terraform/k8s/addons/generate-apps.tf
@@ -15,7 +15,7 @@ resource "local_file" "config-file" {
     {
       cluster : var.clusterConfig
       app : merge(
-        local.default[basename(dirname(dirname(each.key)))][basename(dirname(each.key))],
+        try(local.default[basename(dirname(dirname(each.key)))][basename(dirname(each.key))], {}),
         local.override[dirname(each.key)]
       )
       filename: each.key

--- a/terraform/k8s/addons/generate-apps.tf
+++ b/terraform/k8s/addons/generate-apps.tf
@@ -29,7 +29,7 @@ resource "local_file" "config-file" {
         },
         try(local.addons[basename(dirname(dirname(each.key)))][basename(dirname(each.key))], {}),
         local.apps[basename(dirname(each.key))],
-        try(split("/", filename)[1] == "app-yamls" ? local.apps["app-yamls"][basename(trimsuffix(filename, ".yaml"))] : {}, {})
+        try(split("/", each.key)[1] == "app-yamls" ? local.apps["app-yamls"][basename(trimsuffix(each.key, ".yaml"))] : {}, {})
       )
       apps: local.apps,
       filename: each.key

--- a/terraform/k8s/addons/generate-apps.tf
+++ b/terraform/k8s/addons/generate-apps.tf
@@ -28,7 +28,7 @@ resource "local_file" "config-file" {
           syncWave: 0
         },
         try(local.addons[basename(dirname(dirname(each.key)))][basename(dirname(each.key))], {}),
-        local.apps[basename(dirname(each.key))],
+        try(local.apps[basename(dirname(each.key))], {}),
         try(split("/", each.key)[1] == "app-yamls" ? local.apps["app-yamls"][basename(trimsuffix(each.key, ".yaml"))] : {}, {})
       )
       apps: local.apps,

--- a/terraform/k8s/addons/generate-apps.tf
+++ b/terraform/k8s/addons/generate-apps.tf
@@ -3,7 +3,11 @@ resource "local_file" "config-file" {
     alltrue([for name in split("/", filename) : !startswith(name, ".")]) && # exclude hidden files and folders
     fileexists("${path.module}/${filename}") &&
     (
-      split("/", filename)[1] == "app-yamls" ||
+      split("/", filename)[1] == "app-yamls" ?
+      coalesce(
+        try(local.override["${split("/", filename)[0]}/app-yamls"]["${split("/", trimsuffix(filename, ".yaml"))[2]}Enabled"], null),
+        try(local.default[split("/", filename)[0]]["app-yamls"]["${split("/", trimsuffix(filename, ".yaml"))[2]}Enabled"], false)
+      ) :
       coalesce(
         try(local.override["${split("/", filename)[0]}/app-yamls"]["${split("/", filename)[1]}Enabled"], null),
         try(local.default[split("/", filename)[0]]["app-yamls"]["${split("/", filename)[1]}Enabled"], false)
@@ -29,7 +33,11 @@ resource "local_file" "addon-file" {
     alltrue([for name in split("/", filename) : !startswith(name, ".")]) && # exclude hidden files and folders
     fileexists("${path.module}/${filename}") &&
     (
-      split("/", filename)[1] == "app-yamls" ||
+      split("/", filename)[1] == "app-yamls" ?
+      coalesce(
+        try(local.override["${split("/", filename)[0]}/app-yamls"]["${split("/", trimsuffix(filename, ".yaml"))[2]}Enabled"], null),
+        try(local.default[split("/", filename)[0]]["app-yamls"]["${split("/", trimsuffix(filename, ".yaml"))[2]}Enabled"], false)
+      ) :
       coalesce(
         try(local.override["${split("/", filename)[0]}/app-yamls"]["${split("/", filename)[1]}Enabled"], null),
         try(local.default[split("/", filename)[0]]["app-yamls"]["${split("/", filename)[1]}Enabled"], false)

--- a/terraform/k8s/addons/generate-apps.tf
+++ b/terraform/k8s/addons/generate-apps.tf
@@ -6,12 +6,12 @@ resource "local_file" "config-file" {
       split("/", filename)[1] == "app-yamls" ?
       coalesce(
         try(local.override["${split("/", filename)[0]}/app-yamls"]["${split("/", trimsuffix(filename, ".yaml"))[2]}Enabled"], null),
-        try(local.override["${split("/", filename)[0]}/app-yamls"]["${split("/", trimsuffix(filename, ".yaml"))[2]}"].enabled, null),
+        try(local.override["${split("/", filename)[0]}/app-yamls"][split("/", trimsuffix(filename, ".yaml"))[2]].enabled, null),
         try(local.default[split("/", filename)[0]]["app-yamls"]["${split("/", trimsuffix(filename, ".yaml"))[2]}Enabled"], false)
       ) :
       coalesce(
         try(local.override["${split("/", filename)[0]}/app-yamls"]["${split("/", filename)[1]}Enabled"], null),
-        try(local.override["${split("/", filename)[0]}/app-yamls"]["${split("/", filename)[1]}"].enabled, null),
+        try(local.override["${split("/", filename)[0]}/app-yamls"][split("/", filename)[1]].enabled, null),
         try(local.default[split("/", filename)[0]]["app-yamls"]["${split("/", filename)[1]}Enabled"], false)
       )
     )
@@ -21,8 +21,15 @@ resource "local_file" "config-file" {
     {
       cluster : var.clusterConfig
       app : merge(
+        {
+          name: basename(dirname(each.key)),
+          namespace: basename(dirname(each.key)),
+          enabled: false,
+          syncWave: 0
+        },
         try(local.default[basename(dirname(dirname(each.key)))][basename(dirname(each.key))], {}),
-        local.override[dirname(each.key)]
+        local.override[dirname(each.key)],
+        try(split("/", filename)[1] == "app-yamls" ? local.apps["app-yamls"][basename(trimsuffix(filename, ".yaml"))] : {}, {})
       )
       filename: each.key
     }
@@ -38,12 +45,12 @@ resource "local_file" "addon-file" {
       split("/", filename)[1] == "app-yamls" ?
       coalesce(
         try(local.override["${split("/", filename)[0]}/app-yamls"]["${split("/", trimsuffix(filename, ".yaml"))[2]}Enabled"], null),
-        try(local.override["${split("/", filename)[0]}/app-yamls"]["${split("/", trimsuffix(filename, ".yaml"))[2]}"].enabled, null),
+        try(local.override["${split("/", filename)[0]}/app-yamls"][split("/", trimsuffix(filename, ".yaml"))[2]].enabled, null),
         try(local.default[split("/", filename)[0]]["app-yamls"]["${split("/", trimsuffix(filename, ".yaml"))[2]}Enabled"], false)
       ) :
       coalesce(
         try(local.override["${split("/", filename)[0]}/app-yamls"]["${split("/", filename)[1]}Enabled"], null),
-        try(local.override["${split("/", filename)[0]}/app-yamls"]["${split("/", filename)[1]}"].enabled, null),
+        try(local.override["${split("/", filename)[0]}/app-yamls"][split("/", filename)[1]].enabled, null),
         try(local.default[split("/", filename)[0]]["app-yamls"]["${split("/", filename)[1]}Enabled"], false)
       )
     )
@@ -57,9 +64,12 @@ locals {
     for app in fileset(path.module, "*/default.yaml") :
     dirname(app) => yamldecode(templatefile(app, var.clusterConfig))
   }
-  override = { # load overrides for each addon, keyed by addon-name/folder-name
+  override = { # load overrides for each app, keyed by addon-name/app-name
     for app in distinct([for _, v in fileset(path.module, "*/*/*") : dirname(v)]) :
     app => try(yamldecode(templatefile("${var.configPath}/${basename(app)}.yaml", merge(var.clusterConfig, { cluster: var.clusterConfig }))), {})
+  }
+  apps = {
+    for app_name, app_config in local.override : basename(app_name) => app_config
   }
 }
 

--- a/terraform/k8s/addons/generate-apps.tf
+++ b/terraform/k8s/addons/generate-apps.tf
@@ -28,7 +28,7 @@ resource "local_file" "config-file" {
           syncWave: 0
         },
         try(local.addons[basename(dirname(dirname(each.key)))][basename(dirname(each.key))], {}),
-        local.apps[basename(dirname(each.key))],
+        try(local.apps[endswith(each.key, ".app.yaml") ? trimsuffix(basename(each.key), ".app.yaml") : basename(dirname(each.key))], {}),
         try(split("/", each.key)[1] == "app-yamls" ? local.apps["app-yamls"][basename(trimsuffix(each.key, ".yaml"))] : {}, {})
       )
       apps: local.apps,

--- a/terraform/k8s/addons/generate-apps.tf
+++ b/terraform/k8s/addons/generate-apps.tf
@@ -6,10 +6,12 @@ resource "local_file" "config-file" {
       split("/", filename)[1] == "app-yamls" ?
       coalesce(
         try(local.override["${split("/", filename)[0]}/app-yamls"]["${split("/", trimsuffix(filename, ".yaml"))[2]}Enabled"], null),
+        try(local.override["${split("/", filename)[0]}/app-yamls"]["${split("/", trimsuffix(filename, ".yaml"))[2]}"].enabled, null),
         try(local.default[split("/", filename)[0]]["app-yamls"]["${split("/", trimsuffix(filename, ".yaml"))[2]}Enabled"], false)
       ) :
       coalesce(
         try(local.override["${split("/", filename)[0]}/app-yamls"]["${split("/", filename)[1]}Enabled"], null),
+        try(local.override["${split("/", filename)[0]}/app-yamls"]["${split("/", filename)[1]}"].enabled, null),
         try(local.default[split("/", filename)[0]]["app-yamls"]["${split("/", filename)[1]}Enabled"], false)
       )
     )
@@ -36,10 +38,12 @@ resource "local_file" "addon-file" {
       split("/", filename)[1] == "app-yamls" ?
       coalesce(
         try(local.override["${split("/", filename)[0]}/app-yamls"]["${split("/", trimsuffix(filename, ".yaml"))[2]}Enabled"], null),
+        try(local.override["${split("/", filename)[0]}/app-yamls"]["${split("/", trimsuffix(filename, ".yaml"))[2]}"].enabled, null),
         try(local.default[split("/", filename)[0]]["app-yamls"]["${split("/", trimsuffix(filename, ".yaml"))[2]}Enabled"], false)
       ) :
       coalesce(
         try(local.override["${split("/", filename)[0]}/app-yamls"]["${split("/", filename)[1]}Enabled"], null),
+        try(local.override["${split("/", filename)[0]}/app-yamls"]["${split("/", filename)[1]}"].enabled, null),
         try(local.default[split("/", filename)[0]]["app-yamls"]["${split("/", filename)[1]}Enabled"], false)
       )
     )

--- a/terraform/k8s/addons/generate-apps.tf
+++ b/terraform/k8s/addons/generate-apps.tf
@@ -47,7 +47,7 @@ locals {
   }
   override = { # load overrides for each addon, keyed by addon-name/folder-name
     for app in distinct([for _, v in fileset(path.module, "*/*/*") : dirname(v)]) :
-    app => try(yamldecode(templatefile("${var.configPath}/${basename(app)}.yaml", var.clusterConfig)), {})
+    app => try(yamldecode(templatefile("${var.configPath}/${basename(app)}.yaml", merge(var.clusterConfig, { cluster: var.clusterConfig }))), {})
   }
 }
 


### PR DESCRIPTION
- allow addon configs coming from the profiles
- allow addons to contribute to configuration and work as profiles, meant to activate dependencies
- enable deep merging of addon `xxx` configs that are placed in `xxx/.config/xxx.yaml`
- decouple configuration from `default.yaml` and move it to the `*/.config folder`
- apps no longer need to be put in app-yamls, instead they can be defined in files in the app folder `xxx/xxx.app.yaml`
- apps can access other apps' configuration via `${apps.appName.propertyName}`

Note: this is a backwards compatible change, but usage of the `xxx/app-yamls` folder and `default.yaml` config file is going to be phased out