### PR TITLE
fix: oathkeeper auth provider config

### DIFF
--- a/terraform/gitops/generate-files/templates/istio/istio-main/values-istio-istiod.yaml.tpl
+++ b/terraform/gitops/generate-files/templates/istio/istio-main/values-istio-istiod.yaml.tpl
@@ -181,6 +181,8 @@ meshConfig:
         statusOnError: "500"
         pathPrefix: /decisions
         includeRequestHeadersInCheck: ["authorization", "cookie"]
+        headersToUpstreamOnAllow: ["x-user", "x-email", "x-extra"]
+
 global:
   # Used to locate istiod.
   istioNamespace: ${istio_namespace}


### PR DESCRIPTION
This pull request makes a small configuration update to the Istio mesh configuration. The change adds a new setting to forward specific headers upstream when a request is allowed.

* Added `headersToUpstreamOnAllow` with the headers `x-user`, `x-email`, and `x-extra` to the Istio mesh config in `values-istio-istiod.yaml.tpl` to ensure these headers are passed to upstream services on allowed requests.