### PR TITLE
fix: ensure reload handles creation events

### DIFF
--- a/terraform/gitops/generate-files/templates/base-utils/values-reloader.yaml.tpl
+++ b/terraform/gitops/generate-files/templates/base-utils/values-reloader.yaml.tpl
@@ -1,3 +1,5 @@
 nameOverride: reloader
 reloader:
   resourceLabelSelector: "reloader=enabled"
+  reloadOnCreate: true
+  syncAfterRestart: true


### PR DESCRIPTION
The reloader currently misses the secret creation events, which can happen when manually deleting a secret to trigger certificate reissuance. Deleting a secret is currently our only way to manually renew certificates.