### PR TITLE
chore: add role for mcm patching

### DIFF
--- a/terraform/gitops/generate-files/templates/mcm/vault-agent.yaml.tpl
+++ b/terraform/gitops/generate-files/templates/mcm/vault-agent.yaml.tpl
@@ -33,6 +33,7 @@ metadata:
 rules:
 - apiGroups: [""]
   resources: ["secrets"]
+  resourceNames: ["switch-jws"]
   verbs: ["patch"]
 ---
 apiVersion: rbac.authorization.k8s.io/v1

--- a/terraform/gitops/generate-files/templates/mcm/vault-agent.yaml.tpl
+++ b/terraform/gitops/generate-files/templates/mcm/vault-agent.yaml.tpl
@@ -28,6 +28,30 @@ roleRef:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
+  namespace: ${mojaloop_namespace}
+  name: secret-patch-role
+rules:
+- apiGroups: [""]
+  resources: ["secrets"]
+  verbs: ["patch"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: mcm-secret-patch-binding
+  namespace: ${mojaloop_namespace}
+subjects:
+- kind: ServiceAccount
+  name: ${mcm_service_account_name}
+  namespace: ${mcm_namespace}
+roleRef:
+  kind: Role
+  name: secret-patch-role
+  apiGroup: rbac.authorization.k8s.io
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
   name: create-update-istio-crs
   namespace: ${mojaloop_namespace}
 rules:


### PR DESCRIPTION
This pull request adds new RBAC (Role-Based Access Control) resources to the `vault-agent.yaml.tpl` template to allow patching Kubernetes secrets. The main changes are the introduction of a new `Role` and `RoleBinding` for secret patch permissions.

**RBAC enhancements for secret patching:**

* Added a new `Role` named `secret-patch-role` in the `${mojaloop_namespace}` namespace, granting `patch` permissions on `secrets` resources.
* Added a new `RoleBinding` named `mcm-secret-patch-binding` in the `${mojaloop_namespace}` namespace, binding the `secret-patch-role` to the `${mcm_service_account_name}` service account in the `${mcm_namespace}` namespace.