### PR TITLE
fix: add istio routing for mgnt routes for ui

### DIFF
--- a/terraform/gitops/generate-files/templates/pm4ml/istio-gateway.yaml.tpl
+++ b/terraform/gitops/generate-files/templates/pm4ml/istio-gateway.yaml.tpl
@@ -198,6 +198,48 @@ spec:
   hosts:
   - '${experience_api_fqdn}'
   http:
+    - name: "states"
+      match:
+        - uri:
+            prefix: /states
+      route:
+        - destination:
+            host: ${pm4ml_release_name}-management-api
+            port:
+              number: 80
+          headers:
+            response:
+              set:
+                access-control-allow-origin: "https://${portal_fqdn}"
+                access-control-allow-credentials: "true"
+    - name: "reonboard"
+      match:
+        - uri:
+            prefix: /reonboard
+      route:
+        - destination:
+            host: ${pm4ml_release_name}-management-api
+            port:
+              number: 80
+          headers:
+            response:
+              set:
+                access-control-allow-origin: "https://${portal_fqdn}"
+                access-control-allow-credentials: "true"
+    - name: "recreate"
+      match:
+        - uri:
+            prefix: /recreate
+      route:
+        - destination:
+            host: ${pm4ml_release_name}-management-api
+            port:
+              number: 80
+          headers:
+            response:
+              set:
+                access-control-allow-origin: "https://${portal_fqdn}"
+                access-control-allow-credentials: "true"
     - name: "experience-api"
       match:
         - uri:

--- a/terraform/gitops/generate-files/templates/pm4ml/istio-gateway.yaml.tpl
+++ b/terraform/gitops/generate-files/templates/pm4ml/istio-gateway.yaml.tpl
@@ -188,6 +188,23 @@ spec:
         - operation:
             hosts: ["${experience_api_fqdn}", "${experience_api_fqdn}:*"]
 ---
+apiVersion: security.istio.io/v1beta1
+kind: AuthorizationPolicy
+metadata:
+  name: ${pm4ml_release_name}-management-api-auth
+spec:
+  targetRefs:
+    - kind: Service
+      group: core
+      name: ${pm4ml_release_name}-management-api
+  action: CUSTOM
+  provider:
+    name: ${oathkeeper_auth_provider_name}
+  rules:
+    - to:
+        - operation:
+            hosts: ["${experience_api_fqdn}", "${experience_api_fqdn}:*"]
+---
 apiVersion: networking.istio.io/v1alpha3
 kind: VirtualService
 metadata:

--- a/terraform/gitops/generate-files/templates/pm4ml/istio-gateway.yaml.tpl
+++ b/terraform/gitops/generate-files/templates/pm4ml/istio-gateway.yaml.tpl
@@ -198,36 +198,12 @@ spec:
   hosts:
   - '${experience_api_fqdn}'
   http:
-    - name: "states"
+    - name: "management-api"
       match:
         - uri:
             prefix: /states
-      route:
-        - destination:
-            host: ${pm4ml_release_name}-management-api
-            port:
-              number: 80
-          headers:
-            response:
-              set:
-                access-control-allow-origin: "https://${portal_fqdn}"
-                access-control-allow-credentials: "true"
-    - name: "reonboard"
-      match:
         - uri:
             prefix: /reonboard
-      route:
-        - destination:
-            host: ${pm4ml_release_name}-management-api
-            port:
-              number: 80
-          headers:
-            response:
-              set:
-                access-control-allow-origin: "https://${portal_fqdn}"
-                access-control-allow-credentials: "true"
-    - name: "recreate"
-      match:
         - uri:
             prefix: /recreate
       route:


### PR DESCRIPTION
This pull request adds new HTTP routing rules to the Istio Gateway configuration for the PM4ML management API. The main change is the introduction of three new routes to support `/states`, `/reonboard`, and `/recreate` endpoints, each with appropriate CORS headers to allow requests from the portal frontend.

### API Gateway Routing Updates

* Added a new route for the `/states` endpoint, forwarding requests to the `management-api` service and setting CORS headers for the portal frontend.
* Added a new route for the `/reonboard` endpoint with similar forwarding and CORS configuration.
* Added a new route for the `/recreate` endpoint, also forwarding to the `management-api` service and setting CORS headers.

Tested on dev
<img width="933" height="532" alt="image" src="https://github.com/user-attachments/assets/1242d577-88cb-4bf0-ab36-1dd428d633bf" />
