### PR TITLE
Add Alerts for DFSP disconnections

### DIFF
--- a/terraform/gitops/generate-files/templates/monitoring/install/kustomization.yaml.tpl
+++ b/terraform/gitops/generate-files/templates/monitoring/install/kustomization.yaml.tpl
@@ -34,12 +34,12 @@ helmCharts:
   repo: ${grafana_operator_repo}
   valuesFile: values-grafana-operator.yaml
   namespace: ${monitoring_namespace}
-- name: grafana-loki
-  releaseName: ${loki_release_name}
-  version: ${loki_chart_version}
-  repo: ${loki_repo}
-  valuesFile: values-loki.yaml
-  namespace: ${monitoring_namespace}
+# - name: grafana-loki
+#   releaseName: ${loki_release_name}
+#   version: ${loki_chart_version}
+#   repo: ${loki_repo}
+#   valuesFile: values-loki.yaml
+#   namespace: ${monitoring_namespace}
 - name: loki
   releaseName: loki-official-helm # TODO: update release name to 'loki' once bitnami loki is removed 
   version: 6.45.2          # TODO: use exist helm parameter and update it to this version

--- a/terraform/gitops/generate-files/templates/monitoring/install/kustomization.yaml.tpl
+++ b/terraform/gitops/generate-files/templates/monitoring/install/kustomization.yaml.tpl
@@ -52,12 +52,12 @@ helmCharts:
   repo: https://open-telemetry.github.io/opentelemetry-helm-charts
   valuesFile: values-opentelemetry-operator.yaml
   namespace: ${monitoring_namespace}
-- name: loki-canary
-  releaseName: loki-canary-ext-helm
-  version: ${loki_canary_chart_version}
-  repo: ${loki_canary_repo}
-  valuesFile: values-loki-canary.yaml
-  namespace: ${monitoring_namespace}
+# - name: loki-canary
+#   releaseName: loki-canary-ext-helm
+#   version: ${loki_canary_chart_version}
+#   repo: ${loki_canary_repo}
+#   valuesFile: values-loki-canary.yaml
+#   namespace: ${monitoring_namespace}
 - name: alloy
   releaseName: alloy
   version: 1.4.0

--- a/terraform/gitops/generate-files/templates/monitoring/install/kustomization.yaml.tpl
+++ b/terraform/gitops/generate-files/templates/monitoring/install/kustomization.yaml.tpl
@@ -34,12 +34,12 @@ helmCharts:
   repo: ${grafana_operator_repo}
   valuesFile: values-grafana-operator.yaml
   namespace: ${monitoring_namespace}
-# - name: grafana-loki
-#   releaseName: ${loki_release_name}
-#   version: ${loki_chart_version}
-#   repo: ${loki_repo}
-#   valuesFile: values-loki.yaml
-#   namespace: ${monitoring_namespace}
+- name: grafana-loki
+  releaseName: ${loki_release_name}
+  version: ${loki_chart_version}
+  repo: ${loki_repo}
+  valuesFile: values-loki.yaml
+  namespace: ${monitoring_namespace}
 - name: loki
   releaseName: loki-official-helm # TODO: update release name to 'loki' once bitnami loki is removed 
   version: 6.45.2          # TODO: use exist helm parameter and update it to this version
@@ -52,12 +52,12 @@ helmCharts:
   repo: https://open-telemetry.github.io/opentelemetry-helm-charts
   valuesFile: values-opentelemetry-operator.yaml
   namespace: ${monitoring_namespace}
-# - name: loki-canary
-#   releaseName: loki-canary-ext-helm
-#   version: ${loki_canary_chart_version}
-#   repo: ${loki_canary_repo}
-#   valuesFile: values-loki-canary.yaml
-#   namespace: ${monitoring_namespace}
+- name: loki-canary
+  releaseName: loki-canary-ext-helm
+  version: ${loki_canary_chart_version}
+  repo: ${loki_canary_repo}
+  valuesFile: values-loki-canary.yaml
+  namespace: ${monitoring_namespace}
 - name: alloy
   releaseName: alloy
   version: 1.4.0

--- a/terraform/gitops/generate-files/templates/monitoring/post-config/alerts/dfsp-alerts.yaml.tpl
+++ b/terraform/gitops/generate-files/templates/monitoring/post-config/alerts/dfsp-alerts.yaml.tpl
@@ -3,6 +3,8 @@ kind: PrometheusRule
 metadata:
   name: dfsp-alerts
   namespace: ${monitoring_namespace}
+  labels: 
+    release: prom
 spec:
   groups:
   - name: dfsp.rules

--- a/terraform/gitops/generate-files/templates/monitoring/post-config/alerts/dfsp-alerts.yaml.tpl
+++ b/terraform/gitops/generate-files/templates/monitoring/post-config/alerts/dfsp-alerts.yaml.tpl
@@ -1,0 +1,17 @@
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  name: dfsp-alerts
+  namespace: ${monitoring_namespace}
+spec:
+  groups:
+  - name: dfsp.rules
+    rules:
+    - alert: DFSP_ConnectionError
+      expr: mcm_api_dfsp_status_state > 0 
+      for: 15m
+      labels:
+        severity: critical
+      annotations:
+        summary: "Mojaloop is facing connection errors with dfsp:{{ $labels.dfsp }}"
+        description: "VALUE = {{ $value }}\n  LABELS = {{ $labels }}"


### PR DESCRIPTION
This pull request introduces a new Prometheus alerting rule for DFSP connection errors to the monitoring configuration. The change adds a template file that defines a critical alert when the `mcm_api_dfsp_status_state` metric indicates a connection error for more than 15 minutes.

Monitoring and alerting:

* Added `dfsp-alerts.yaml.tpl` to define a `PrometheusRule` that triggers a critical alert (`DFSP_ConnectionError`) when `mcm_api_dfsp_status_state` is greater than 0 for 15 minutes, notifying operators of DFSP connection issues.