### PR TITLE
Fix/pxc backup

### DIFF
--- a/terraform/ccnew/default-config/common-vars.yaml
+++ b/terraform/ccnew/default-config/common-vars.yaml
@@ -79,7 +79,7 @@ netbird_operator_helm_version: "0.1.15"
 
 # percona operator helm chart versions
 pg_operator_helm_version: "2.6.0"
-pxc_operator_helm_version: "1.17.0"
+pxc_operator_helm_version: "1.18.0"
 psmdb_operator_helm_version: "1.19.1"
 
 stunner_gateway_operator_helm_version: "0.19.0"

--- a/terraform/gitops/generate-files/templates/crossplane/crossplane-values.yaml.tpl
+++ b/terraform/gitops/generate-files/templates/crossplane/crossplane-values.yaml.tpl
@@ -1,7 +1,3 @@
 args:
   - --debug
   - --enable-usages
-tolerations:
-  - key: "netbird/ready"
-    operator: "Exists"
-    effect: "NoSchedule"

--- a/terraform/gitops/generate-files/templates/crossplane/kustomization.yaml.tpl
+++ b/terraform/gitops/generate-files/templates/crossplane/kustomization.yaml.tpl
@@ -9,3 +9,11 @@ helmCharts:
     namespace: ${crossplane_namespace}
     valuesFile: crossplane-values.yaml
     version: ${crossplane_helm_version}
+
+patches:
+  - path: toleration-patch.yaml
+    target:
+      kind: Deployment
+  - path: toleration-patch.yaml
+    target:
+      kind: DaemonSet

--- a/terraform/gitops/generate-files/templates/crossplane/toleration-patch.yaml.tpl
+++ b/terraform/gitops/generate-files/templates/crossplane/toleration-patch.yaml.tpl
@@ -1,0 +1,6 @@
+- op: add
+  path: /spec/template/spec/tolerations
+  value:
+    - key: "netbird/ready"
+      operator: "Exists"
+      effect: "NoSchedule"

--- a/terraform/gitops/generate-files/templates/storage/rook-ceph-storage-class.yaml.tpl
+++ b/terraform/gitops/generate-files/templates/storage/rook-ceph-storage-class.yaml.tpl
@@ -8,19 +8,22 @@ metadata:
   name: ${block_storage_class_name}
 parameters:
   clusterID: ${storage_namespace}
+  imageFeatures: layering
+  imageFormat: "2"
+  pool: ceph-blockpool
   csi.storage.k8s.io/controller-expand-secret-name: rook-csi-rbd-provisioner
   csi.storage.k8s.io/controller-expand-secret-namespace: ${storage_namespace}
-  csi.storage.k8s.io/fstype: ext4
   csi.storage.k8s.io/node-stage-secret-name: rook-csi-rbd-node
   csi.storage.k8s.io/node-stage-secret-namespace: ${storage_namespace}
   csi.storage.k8s.io/provisioner-secret-name: rook-csi-rbd-provisioner
   csi.storage.k8s.io/provisioner-secret-namespace: ${storage_namespace}
-  imageFeatures: layering
-  imageFormat: "2"
-  pool: ceph-blockpool
+  mounter: rbd-nbd
+  mapOptions: "krbd:r_retry_errors"
+  unmapOptions: "force"
+  csi.storage.k8s.io/fstype: ext4
 provisioner: "${storage_namespace}.rbd.csi.ceph.com"
 reclaimPolicy: Delete
-volumeBindingMode: Immediate
+volumeBindingMode: WaitForFirstConsumer
 allowVolumeExpansion: true
 
 ---

--- a/terraform/gitops/generate-files/templates/storage/rook-ceph-storage-class.yaml.tpl
+++ b/terraform/gitops/generate-files/templates/storage/rook-ceph-storage-class.yaml.tpl
@@ -23,7 +23,7 @@ parameters:
   csi.storage.k8s.io/fstype: ext4
 provisioner: "${storage_namespace}.rbd.csi.ceph.com"
 reclaimPolicy: Delete
-volumeBindingMode: Immediate
+volumeBindingMode: WaitForFirstConsumer
 allowVolumeExpansion: true
 
 ---

--- a/terraform/gitops/generate-files/templates/storage/rook-ceph-storage-class.yaml.tpl
+++ b/terraform/gitops/generate-files/templates/storage/rook-ceph-storage-class.yaml.tpl
@@ -23,7 +23,7 @@ parameters:
   csi.storage.k8s.io/fstype: ext4
 provisioner: "${storage_namespace}.rbd.csi.ceph.com"
 reclaimPolicy: Delete
-volumeBindingMode: WaitForFirstConsumer
+volumeBindingMode: Immediate
 allowVolumeExpansion: true
 
 ---

--- a/terraform/gitops/generate-files/templates/vault/app/vault-app.yaml.tpl
+++ b/terraform/gitops/generate-files/templates/vault/app/vault-app.yaml.tpl
@@ -16,12 +16,6 @@ spec:
     namespace: ${vault_namespace}
     server: https://kubernetes.default.svc
   project: default
-  ignoreDifferences:
-    - group: ""
-      kind: PersistentVolumeClaim
-      jqPathExpressions:
-        - .spec.dataSource
-        - .spec.dataSourceRef
   syncPolicy:
     automated:
       prune: true

--- a/terraform/gitops/generate-files/templates/vault/app/vault-app.yaml.tpl
+++ b/terraform/gitops/generate-files/templates/vault/app/vault-app.yaml.tpl
@@ -16,6 +16,12 @@ spec:
     namespace: ${vault_namespace}
     server: https://kubernetes.default.svc
   project: default
+  ignoreDifferences:
+    - group: ""
+      kind: PersistentVolumeClaim
+      jqPathExpressions:
+        - .spec.dataSource
+        - .spec.dataSourceRef
   syncPolicy:
     automated:
       prune: true

--- a/terraform/gitops/generate-files/templates/vault/vault-helm.yaml.tpl
+++ b/terraform/gitops/generate-files/templates/vault/vault-helm.yaml.tpl
@@ -17,12 +17,17 @@ spec:
   destination:
     namespace: ${vault_namespace}
     server: https://kubernetes.default.svc
-  project: default
+  project: default  
   ignoreDifferences:
-  - group: admissionregistration.k8s.io
-    kind: MutatingWebhookConfiguration
-    jqPathExpressions:
-    - .webhooks[]?.clientConfig.caBundle
+    - group: admissionregistration.k8s.io
+      kind: MutatingWebhookConfiguration
+      jqPathExpressions:
+      - .webhooks[]?.clientConfig.caBundle
+    - group: ""
+      kind: PersistentVolumeClaim
+      jqPathExpressions:
+        - .spec.dataSource
+        - .spec.dataSourceRef
   syncPolicy:
     automated:
       prune: true

--- a/terraform/gitops/generate-files/templates/vault/vault-helm.yaml.tpl
+++ b/terraform/gitops/generate-files/templates/vault/vault-helm.yaml.tpl
@@ -19,15 +19,10 @@ spec:
     server: https://kubernetes.default.svc
   project: default  
   ignoreDifferences:
-    - group: admissionregistration.k8s.io
-      kind: MutatingWebhookConfiguration
-      jqPathExpressions:
-      - .webhooks[]?.clientConfig.caBundle
-    - group: ""
-      kind: PersistentVolumeClaim
-      jqPathExpressions:
-        - .spec.dataSource
-        - .spec.dataSourceRef
+  - group: admissionregistration.k8s.io
+    kind: MutatingWebhookConfiguration
+    jqPathExpressions:
+    - .webhooks[]?.clientConfig.caBundle
   syncPolicy:
     automated:
       prune: true

--- a/terraform/gitops/stateful-resources/templates/stateful-resources/dbaas/mongodb/db-cluster.yaml.tpl
+++ b/terraform/gitops/stateful-resources/templates/stateful-resources/dbaas/mongodb/db-cluster.yaml.tpl
@@ -33,7 +33,7 @@ spec:
       bucketRegion: ${backup_bucket_region}
       scheduleEnabled: ${schedule_enabled}
       scheduleName: ${backup_schedule_name}
-      cronScheduleExpression: ${backup_cron_schedule}
+      cronScheduleExpression: "${backup_cron_schedule}"
       backupRetention: ${backup_retention}
 
     replsets:

--- a/terraform/gitops/stateful-resources/templates/stateful-resources/dbaas/mysql/db-cluster.yaml.tpl
+++ b/terraform/gitops/stateful-resources/templates/stateful-resources/dbaas/mysql/db-cluster.yaml.tpl
@@ -84,7 +84,7 @@ spec:
       bucketRegion: ${cloud_region}
       endpointUrl: "https://s3.${cloud_region}.amazonaws.com"
       scheduleName: ${backup_schedule_name}
-      cronScheduleExpression: ${backup_cron_schedule}
+      cronScheduleExpression: "${backup_cron_schedule}"
       backupRetention: ${backup_retention}
       pvc: ${backup_pvc}
 

--- a/terraform/k8s/default-config/common-vars.yaml
+++ b/terraform/k8s/default-config/common-vars.yaml
@@ -82,7 +82,7 @@ crossplane_packages_utils_version: "v0.8.0"
 crossplane_packages_objectstores_version: "v0.2.0"
 crossplane_packages_aws_documentdb_version: "v0.6.0"
 crossplane_packages_aws_rds_version: "v0.4.0"
-crossplane_packages_sc_mysql_version: "v0.7.1"
+crossplane_packages_sc_mysql_version: "v0.7.1-pr111-20224386885"
 crossplane_packages_sc_mongodb_version: "v0.5.1"
 max_pods_per_node: 110
 velero_plugin_version: 'v1.12.1'

--- a/terraform/k8s/default-config/common-vars.yaml
+++ b/terraform/k8s/default-config/common-vars.yaml
@@ -82,7 +82,7 @@ crossplane_packages_utils_version: "v0.8.0"
 crossplane_packages_objectstores_version: "v0.2.0"
 crossplane_packages_aws_documentdb_version: "v0.6.0"
 crossplane_packages_aws_rds_version: "v0.4.0"
-crossplane_packages_sc_mysql_version: "v0.7.1-pr111-20224386885"
+crossplane_packages_sc_mysql_version: "v0.8.0"
 crossplane_packages_sc_mongodb_version: "v0.5.1"
 max_pods_per_node: 110
 velero_plugin_version: 'v1.12.1'

--- a/terraform/k8s/default-config/mojaloop-stateful-resources-monolith-databases.yaml
+++ b/terraform/k8s/default-config/mojaloop-stateful-resources-monolith-databases.yaml
@@ -11,7 +11,7 @@ common_platform_db:
     # Percona XtraDB Cluster (PXC) specific configurations
     management_policy: "*"
     cluster_name: "common-platform-db"                         # Name of the cluster
-    cr_version: "1.17.0"                                       # Custom Resource version for the operator
+    cr_version: "1.18.0"                                       # Custom Resource version for the operator
     pxc_image: "percona/percona-xtradb-cluster:8.4.6-6.1"      # Docker image for the PXC nodes
     image_pull_policy: "IfNotPresent"                          # Image pull policy for the PXC nodes
     mysql_storage_size: "30Gi"                                 # Storage size for MySQL data
@@ -22,7 +22,7 @@ common_platform_db:
     mysql_limits_cpu: "16000m"                                 # CPU limit for MySQL pods
 
     # HAProxy specific configurations (for load balancing)
-    haproxy_image: "percona/haproxy:2.8.11"                      # Docker image for the HAProxy instances
+    haproxy_image: "percona/haproxy:2.8.15"                      # Docker image for the HAProxy instances
     haproxy_expose: "true"                                       # Whether HAProxy should be exposed
     haproxy_replicas: 1                                          # Number of HAProxy replicas
     haproxy_requests_memory: "512Mi"                             # Memory request for HAProxy pods
@@ -38,8 +38,8 @@ common_platform_db:
     logcollector_limits_cpu: "200m"                              # CPU limit for log collector
 
     # Backup specific configurations
-    enable_backup: false
-    backup_image: "percona/percona-xtradb-cluster-operator:1.17.0-pxc8.4-backup-pxb8.4.0"   # Docker image for the backup tool
+    enable_backup: true
+    backup_image: "percona/percona-xtrabackup:8.0.35-34.1"       # Docker image for the backup tool
     backup_verify_tls: "false"
     backup_schedule_name: "daily_backup"                         # Name for the backup schedule
     backup_cron_schedule: "0 0 * * *"                            # Cron expression for daily backup at midnight
@@ -150,7 +150,7 @@ common_mojaloop_db:
     # Percona XtraDB Cluster (PXC) specific configurations
     management_policy: "*"
     cluster_name: "common-mojaloop-db"                           # Name of the cluster
-    cr_version: "1.17.0"                                         # Custom Resource version for the operator
+    cr_version: "1.18.0"                                         # Custom Resource version for the operator
     pxc_image: "percona/percona-xtradb-cluster:8.4.6-6.1"        # Docker image for the PXC nodes
     mysql_storage_size: "30Gi"                                   # Storage size for MySQL data
     mysql_replicas: 1                                            # Number of MySQL replicas in the cluster
@@ -160,7 +160,7 @@ common_mojaloop_db:
     mysql_limits_cpu: "16000m"                                   # CPU limit for MySQL pods
 
     # HAProxy specific configurations (for load balancing)
-    haproxy_image: "percona/haproxy:2.8.11"                      # Docker image for the HAProxy instances
+    haproxy_image: "percona/haproxy:2.8.15"                      # Docker image for the HAProxy instances
     haproxy_expose: "true"                                       # Whether HAProxy should be exposed
     haproxy_replicas: 1                                          # Number of HAProxy replicas
     haproxy_requests_memory: "512Mi"                             # Memory request for HAProxy pods
@@ -176,8 +176,8 @@ common_mojaloop_db:
     logcollector_limits_cpu: "200m"                              # CPU limit for log collector
 
     # Backup specific configurations
-    enable_backup: false
-    backup_image: "percona/percona-xtradb-cluster-operator:1.17.0-pxc8.4-backup-pxb8.4.0"   # Docker image for the backup tool
+    enable_backup: true
+    backup_image: "percona/percona-xtrabackup:8.0.35-34.1"       # Docker image for the backup tool
     backup_verify_tls: "false"                                   # Whether to verify TLS for backup
     backup_schedule_name: "daily_backup"                         # Name for the backup schedule
     backup_cron_schedule: "0 0 * * *"                            # Cron expression for daily backup at midnight

--- a/terraform/k8s/default-config/mojaloop-stateful-resources-monolith-databases.yaml
+++ b/terraform/k8s/default-config/mojaloop-stateful-resources-monolith-databases.yaml
@@ -40,7 +40,7 @@ common_platform_db:
     # Backup specific configurations
     enable_backup: true
     backup_image: "percona/percona-xtrabackup:8.0.35-34.1"       # Docker image for the backup tool
-    backup_verify_tls: "false"
+    backup_verify_tls: "true"
     backup_schedule_name: "daily_backup"                         # Name for the backup schedule
     backup_cron_schedule: "0 0 * * *"                            # Cron expression for daily backup at midnight
     backup_retention: "3"                                        # Number of backups to retain
@@ -178,7 +178,7 @@ common_mojaloop_db:
     # Backup specific configurations
     enable_backup: true
     backup_image: "percona/percona-xtrabackup:8.0.35-34.1"       # Docker image for the backup tool
-    backup_verify_tls: "false"                                   # Whether to verify TLS for backup
+    backup_verify_tls: "true"                                   # Whether to verify TLS for backup
     backup_schedule_name: "daily_backup"                         # Name for the backup schedule
     backup_cron_schedule: "0 0 * * *"                            # Cron expression for daily backup at midnight
     backup_retention: "3"                                        # Number of backups to retain


### PR DESCRIPTION
This pull request updates several Kubernetes and database operator configurations, focusing on improving backup reliability, updating operator and image versions, and enhancing storage settings. The most significant changes are grouped below.

**Database Operator and Backup Improvements**

* Upgraded Percona XtraDB Cluster (PXC) operator version from `1.17.0` to `1.18.0`
* Switched the HAProxy image to a newer version (`2.8.15`) for both databases. 
* Enabled backups by default, changed the backup image to `percona/percona-xtrabackup:8.0.35-34.1`, and enabled TLS verification for backups.
* Updated the MySQL Crossplane package version from `v0.7.1` to `v0.8.0`