### PR TITLE
enable psmb backup

### DIFF
--- a/terraform/k8s/default-config/mojaloop-stateful-resources-monolith-databases.yaml
+++ b/terraform/k8s/default-config/mojaloop-stateful-resources-monolith-databases.yaml
@@ -291,13 +291,13 @@ common_mongodb:
     image_pull_policy: "IfNotPresent"
 
     # Backup inputs
-    enable_backup: false
+    enable_backup: true
     backup_image: "percona/percona-backup-mongodb:2.8.0-multi"
     backup_verify_tls: true
     backup_schedule_name: "daily-backup"
     backup_cron_schedule: "0 0 * * *"
     backup_retention: 7
-    schedule_enabled: false
+    schedule_enabled: true
 
     # Replset inputs
     replset_name: "rs0"


### PR DESCRIPTION
This pull request enables automated backups for the `common_mongodb` database in the monolith deployment configuration. The backup process is now active and scheduled to run daily.

Backup configuration changes:

* Enabled the backup feature by setting `enable_backup` to `true` (`terraform/k8s/default-config/mojaloop-stateful-resources-monolith-databases.yaml`)
* Activated the backup schedule by setting `schedule_enabled` to `true` (`terraform/k8s/default-config/mojaloop-stateful-resources-monolith-databases.yaml`)