### PR TITLE
Fix grafana communication with loki-v2

### DIFF
--- a/terraform/gitops/generate-files/templates/monitoring/install/authorization-grafana.yaml.tpl
+++ b/terraform/gitops/generate-files/templates/monitoring/install/authorization-grafana.yaml.tpl
@@ -46,6 +46,21 @@ spec:
 apiVersion: security.istio.io/v1
 kind: AuthorizationPolicy
 metadata:
+  name: grafana-allow-loki-v2
+spec:
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: loki
+  action: ALLOW
+  rules:
+    - from:
+        - source:
+            serviceAccounts:
+              - monitoring/grafana-sa
+---
+apiVersion: security.istio.io/v1
+kind: AuthorizationPolicy
+metadata:
   name: grafana-allow-prometheus
 spec:
   selector:


### PR DESCRIPTION
This pull request adds a new Istio `AuthorizationPolicy` for Grafana to allow access to Loki, expanding monitoring service permissions.

**Monitoring authorization policy updates:**

* Added a new `AuthorizationPolicy` named `grafana-allow-loki-v2` to permit the `monitoring/grafana-sa` service account to access resources labeled with `app.kubernetes.io/name: loki`.