### PR TITLE
fix: add readiness check for Istio CNI in taint remover script

### DIFF
--- a/gitops/applications/base/istio/istio-cni-values.yaml
+++ b/gitops/applications/base/istio/istio-cni-values.yaml
@@ -46,3 +46,4 @@ ambient:
 
 repair:
   enabled: true
+  deletePods: true

--- a/gitops/applications/base/istio/istio-cni-values.yaml
+++ b/gitops/applications/base/istio/istio-cni-values.yaml
@@ -46,4 +46,3 @@ ambient:
 
 repair:
   enabled: true
-  deletePods: true

--- a/terraform/gitops/generate-files/templates/istio/istio-main/values-istio-cni.yaml.tpl
+++ b/terraform/gitops/generate-files/templates/istio/istio-main/values-istio-cni.yaml.tpl
@@ -48,3 +48,4 @@ ambient:
 
 repair:
   enabled: true
+  deletePods: true

--- a/terraform/gitops/generate-files/templates/istio/istio-main/values-istio-cni.yaml.tpl
+++ b/terraform/gitops/generate-files/templates/istio/istio-main/values-istio-cni.yaml.tpl
@@ -26,6 +26,7 @@ cniBinDir: /opt/cni/bin
 cniConfDir: /etc/cni/net.d
 cniConfFileName: ""
 cniNetnsDir: "/var/run/netns"
+istioOwnedCNIConfig : true
 
 excludeNamespaces:
   - kube-system
@@ -42,7 +43,7 @@ ambient:
   # If enabled, and ambient is enabled, enables ipv6 support
   ipv6: false
   # If enabled, and ambient is enabled, the CNI agent will reconcile incompatible iptables rules and chains at startup.
-  reconcileIptablesOnStartup: false
+  reconcileIptablesOnStartup: true
   # If enabled, and ambient is enabled, the CNI agent will always share the network namespace of the host node it is running on
   shareHostNetworkNamespace: false
 

--- a/terraform/gitops/generate-files/templates/keycloak/post-config/keycloak-cr.yaml.tpl
+++ b/terraform/gitops/generate-files/templates/keycloak/post-config/keycloak-cr.yaml.tpl
@@ -35,8 +35,10 @@ spec:
               - sh
               - '-c'
               - >-
-                until nslookup ${keycloak_mysql_host}; do
-                echo waiting for DNS ; sleep 5; done;
+                attempt=0; max_attempts=10;
+                until nslookup ${keycloak_mysql_host} || [ $attempt -eq $max_attempts ]; do
+                attempt=$((attempt+1));
+                echo "waiting for DNS (attempt $attempt/$max_attempts)"; sleep 5; done;
             imagePullPolicy: IfNotPresent
           - name: convert-pem-to-jks
             image: ${keycloak_jdk_image}

--- a/terraform/gitops/generate-files/templates/kyverno/ambient-mode-ns-policy.yaml.tpl
+++ b/terraform/gitops/generate-files/templates/kyverno/ambient-mode-ns-policy.yaml.tpl
@@ -18,6 +18,7 @@ spec:
                 - "kube-system"
                 - "kube-public"
                 - "istio-system"
+                - "kubescape"
 %{ if length(opt_out_namespace_list) > 0 ~}
 %{ for ns in opt_out_namespace_list ~}
                 - "${ns}"

--- a/terraform/gitops/generate-files/templates/kyverno/image-rewrite-policy.yaml.tpl
+++ b/terraform/gitops/generate-files/templates/kyverno/image-rewrite-policy.yaml.tpl
@@ -19,6 +19,7 @@ spec:
             namespaces:
             - istio-ingress-ext
             - istio-ingress-int
+            - "kubescape"
       mutate:
         foreach:
           - list: request.object.spec.containers[]

--- a/terraform/gitops/generate-files/templates/netbird-operator/node-taint-remover.yaml.tpl
+++ b/terraform/gitops/generate-files/templates/netbird-operator/node-taint-remover.yaml.tpl
@@ -34,7 +34,9 @@ spec:
                     jq -r '.items[] | select(.status.phase=="Running") | .status.conditions[] | select(.type=="Ready") | .status' | grep -q True && echo "yes" || echo "no")
                 WAYPOINT_READY=$(kubectl get pod -n istio-system -l gateway.networking.k8s.io/gateway-name=nb-egress-waypoint -o json | \
                     jq -r '.items[] | select(.status.phase=="Running") | .status.conditions[] | select(.type=="Ready") | .status' | grep -q True && echo "yes" || echo "no")
-                if [ "$NETBIRD_READY" = "yes" ] && [ "$WAYPOINT_READY" = "yes" ]; then
+                ISTIO_CNI_READY=$(kubectl get pod -n istio-system -l k8s-app=istio-cni-node -o json | \
+                    jq -r '.items[] | select(.status.phase=="Running") | .status.conditions[] | select(.type=="Ready") | .status' | grep -q True && echo "yes" || echo "no")
+                if [ "$NETBIRD_READY" = "yes" ] && [ "$WAYPOINT_READY" = "yes" ]  && [ "$ISTIO_CNI_READY" = "yes" ]; then
                     kubectl taint node "$NODE_NAME" netbird/ready:NoSchedule-
                 else
                     kubectl taint node "$NODE_NAME" netbird/ready=false:NoSchedule --overwrite

--- a/terraform/gitops/generate-files/templates/netbird-operator/node-taint-remover.yaml.tpl
+++ b/terraform/gitops/generate-files/templates/netbird-operator/node-taint-remover.yaml.tpl
@@ -34,7 +34,7 @@ spec:
                     jq -r '.items[] | select(.status.phase=="Running") | .status.conditions[] | select(.type=="Ready") | .status' | grep -q True && echo "yes" || echo "no")
                 WAYPOINT_READY=$(kubectl get pod -n istio-system -l gateway.networking.k8s.io/gateway-name=nb-egress-waypoint -o json | \
                     jq -r '.items[] | select(.status.phase=="Running") | .status.conditions[] | select(.type=="Ready") | .status' | grep -q True && echo "yes" || echo "no")
-                ISTIO_CNI_READY=$(kubectl get pod -n istio-system --field-selector spec.nodeName=$NODE_NAME -l k8s-app=istio-cni-node -o json | \
+                ISTIO_CNI_READY=$(kubectl get pod -n istio-system --field-selector spec.nodeName="$NODE_NAME" -l k8s-app=istio-cni-node -o json | \
                     jq -r '.items[] | select(.status.phase=="Running") | .status.conditions[] | select(.type=="Ready") | .status' | grep -q True && echo "yes" || echo "no")
                 if [ "$NETBIRD_READY" = "yes" ] && [ "$WAYPOINT_READY" = "yes" ]  && [ "$ISTIO_CNI_READY" = "yes" ]; then
                     kubectl taint node "$NODE_NAME" netbird/ready:NoSchedule-

--- a/terraform/gitops/generate-files/templates/netbird-operator/node-taint-remover.yaml.tpl
+++ b/terraform/gitops/generate-files/templates/netbird-operator/node-taint-remover.yaml.tpl
@@ -34,7 +34,7 @@ spec:
                     jq -r '.items[] | select(.status.phase=="Running") | .status.conditions[] | select(.type=="Ready") | .status' | grep -q True && echo "yes" || echo "no")
                 WAYPOINT_READY=$(kubectl get pod -n istio-system -l gateway.networking.k8s.io/gateway-name=nb-egress-waypoint -o json | \
                     jq -r '.items[] | select(.status.phase=="Running") | .status.conditions[] | select(.type=="Ready") | .status' | grep -q True && echo "yes" || echo "no")
-                ISTIO_CNI_READY=$(kubectl get pod -n istio-system -l k8s-app=istio-cni-node -o json | \
+                ISTIO_CNI_READY=$(kubectl get pod -n istio-system --field-selector spec.nodeName=$NODE_NAME -l k8s-app=istio-cni-node -o json | \
                     jq -r '.items[] | select(.status.phase=="Running") | .status.conditions[] | select(.type=="Ready") | .status' | grep -q True && echo "yes" || echo "no")
                 if [ "$NETBIRD_READY" = "yes" ] && [ "$WAYPOINT_READY" = "yes" ]  && [ "$ISTIO_CNI_READY" = "yes" ]; then
                     kubectl taint node "$NODE_NAME" netbird/ready:NoSchedule-

--- a/terraform/k8s/default-config/common-vars.yaml
+++ b/terraform/k8s/default-config/common-vars.yaml
@@ -10,7 +10,7 @@ vault_config_operator_helm_chart_version: 0.8.28
 nginx_helm_chart_version: 4.6.1
 keycloak_operator_version: 22.0.2
 keycloak_jdk_image: eclipse-temurin:21-jdk
-istio_chart_version: 1.26.1
+istio_chart_version: 1.27.5
 external_secrets_version: 0.8.2
 argocd_version: 3.0.5
 argocd_lovely_plugin_version: 0.18.0


### PR DESCRIPTION
This pull request introduces several configuration updates and reliability improvements across Istio, Keycloak, Kyverno, and Netbird operator templates. The most significant changes include upgrading the Istio chart version, enhancing readiness checks, and improving robustness in startup scripts. Additionally, new namespaces are added to Kyverno and image rewrite policies for better integration.

**Istio CNI and Chart Upgrades:**
- Upgraded `istio_chart_version` from `1.26.1` to `1.27.5` in `common-vars.yaml`, aligning with the latest features and security updates.
- Enabled `istioOwnedCNIConfig` and set `reconcileIptablesOnStartup` to `true` in Istio CNI values, and enabled pod deletion for repairs, improving CNI management and reliability. [[1]](diffhunk://#diff-fd16d41062f22f0d75f987ff8a3de367b84dcc701bcab266725bcf346baae96eR29) [[2]](diffhunk://#diff-fd16d41062f22f0d75f987ff8a3de367b84dcc701bcab266725bcf346baae96eL45-R52)

**Keycloak Startup Robustness:**
- Enhanced the Keycloak MySQL host DNS wait loop to limit retry attempts and provide clearer logging, preventing infinite loops and improving startup diagnostics.

**Kyverno Policy Namespace Exclusion:**
- Added the `kubescape` namespace to both the ambient mode namespace opt-out policy and the image rewrite policy, ensuring these policies do not apply to this namespace. [[1]](diffhunk://#diff-17eefbb434484a4b6d6ea91418879804d98f383d0e22d776957ec4761bcce563R21) [[2]](diffhunk://#diff-7573d8bfb4b24824b0df8d038193aa3c2ad56b8bdf7898c56a2e658beaa8967bR22)

**Netbird Operator Readiness Check:**
- Improved node taint remover logic to also check readiness of the Istio CNI pod before removing taints, ensuring all required components are healthy before proceeding.