### PR TITLE
fix: prometheus stack repo name

### DIFF
--- a/terraform/gitops/generate-files/templates/monitoring/install/kustomization.yaml.tpl
+++ b/terraform/gitops/generate-files/templates/monitoring/install/kustomization.yaml.tpl
@@ -22,7 +22,7 @@ helmCharts:
   releaseName: prometheus-operator-crds
   version: ${prometheus_crd_version}
   repo: ${prometheus_crd_repo}
-- name: kube-prometheus
+- name: kube-prometheus-stack
   releaseName: ${prometheus_operator_release_name}
   version: ${prometheus_operator_version}
   repo: ${prometheus_operator_repo}


### PR DESCRIPTION
Fix ArgoCD monitoring deployment by correcting the Helm chart name from kube-prometheus to kube-prometheus-stack