### PR TITLE
Add tolerations for loki and prometheus

### DIFF
--- a/terraform/gitops/generate-files/templates/monitoring/install/values-alloy.yaml.tpl
+++ b/terraform/gitops/generate-files/templates/monitoring/install/values-alloy.yaml.tpl
@@ -12,3 +12,19 @@ alloy:
     create: false
     name: alloy-config
     key: alloy-config.alloy
+
+controller:
+  nodeSelector:
+    workload-class.mojaloop.io/MONITORING: "enabled"
+  
+%{if length(tolerations) > 0 ~}
+  tolerations:
+%{ for t in tolerations ~}
+  - effect: "${t.effect}"
+    key: "${t.key}"
+    operator: "${t.operator}"
+    value: "${t.value}"
+%{ endfor ~}
+%{ else ~}
+  tolerations: []
+%{ endif ~}

--- a/terraform/gitops/generate-files/templates/monitoring/install/values-loki-official-helm.yaml.tpl
+++ b/terraform/gitops/generate-files/templates/monitoring/install/values-loki-official-helm.yaml.tpl
@@ -104,10 +104,17 @@ ingester:
     enabled: false
   extraArgs:
     - -config.expand-env=true
-  nodeAffinityPreset:
-    type: hard
-    key: workload-class.mojaloop.io/MONITORING
-    values: ["enabled"]
+  nodeSelector:
+    workload-class.mojaloop.io/MONITORING: "enabled"
+%{if length(tolerations) > 0 ~}
+  tolerations:
+%{ for t in tolerations ~}
+  - effect: "${t.effect}"
+    key: "${t.key}"
+    operator: "${t.operator}"
+    value: "${t.value}"
+%{ endfor ~}
+%{ endif ~}
 
 # Distributor configuration
 distributor:
@@ -125,10 +132,17 @@ distributor:
         name: ${object_store_loki_credentials_secret_name}
   extraArgs:
     - -config.expand-env=true
-  nodeAffinityPreset:
-    type: hard
-    key: workload-class.mojaloop.io/MONITORING
-    values: ["enabled"]
+  nodeSelector:
+    workload-class.mojaloop.io/MONITORING: "enabled"
+%{if length(tolerations) > 0 ~}
+  tolerations:
+%{ for t in tolerations ~}
+  - effect: "${t.effect}"
+    key: "${t.key}"
+    operator: "${t.operator}"
+    value: "${t.value}"
+%{ endfor ~}
+%{ endif ~}
 
 # Querier configuration
 querier:
@@ -143,10 +157,17 @@ querier:
         name: ${object_store_loki_credentials_secret_name}
   extraArgs:
     - -config.expand-env=true
-  nodeAffinityPreset:
-    type: hard
-    key: workload-class.mojaloop.io/MONITORING
-    values: ["enabled"]
+  nodeSelector:
+    workload-class.mojaloop.io/MONITORING: "enabled"
+%{if length(tolerations) > 0 ~}
+  tolerations:
+%{ for t in tolerations ~}
+  - effect: "${t.effect}"
+    key: "${t.key}"
+    operator: "${t.operator}"
+    value: "${t.value}"
+%{ endfor ~}
+%{ endif ~}
 
 # Query Frontend configuration
 queryFrontend:
@@ -160,10 +181,17 @@ queryFrontend:
         name: ${object_store_loki_credentials_secret_name}
   extraArgs:
     - -config.expand-env=true
-  nodeAffinityPreset:
-    type: hard
-    key: workload-class.mojaloop.io/MONITORING
-    values: ["enabled"]
+  nodeSelector:
+    workload-class.mojaloop.io/MONITORING: "enabled"
+%{if length(tolerations) > 0 ~}
+  tolerations:
+%{ for t in tolerations ~}
+  - effect: "${t.effect}"
+    key: "${t.key}"
+    operator: "${t.operator}"
+    value: "${t.value}"
+%{ endfor ~}
+%{ endif ~}
 
 # Query Scheduler configuration
 queryScheduler:
@@ -177,10 +205,17 @@ queryScheduler:
         name: ${object_store_loki_credentials_secret_name}
   extraArgs:
     - -config.expand-env=true
-  nodeAffinityPreset:
-    type: hard
-    key: workload-class.mojaloop.io/MONITORING
-    values: ["enabled"]
+  nodeSelector:
+    workload-class.mojaloop.io/MONITORING: "enabled"
+%{if length(tolerations) > 0 ~}
+  tolerations:
+%{ for t in tolerations ~}
+  - effect: "${t.effect}"
+    key: "${t.key}"
+    operator: "${t.operator}"
+    value: "${t.value}"
+%{ endfor ~}
+%{ endif ~}
 
 
 # Compactor configuration
@@ -198,11 +233,17 @@ compactor:
     size: 10Gi
   extraArgs:
     - -config.expand-env=true
-  nodeAffinityPreset:
-    type: hard
-    key: workload-class.mojaloop.io/MONITORING
-    values: ["enabled"]
-
+  nodeSelector:
+    workload-class.mojaloop.io/MONITORING: "enabled"
+%{if length(tolerations) > 0 ~}
+  tolerations:
+%{ for t in tolerations ~}
+  - effect: "${t.effect}"
+    key: "${t.key}"
+    operator: "${t.operator}"
+    value: "${t.value}"
+%{ endfor ~}
+%{ endif ~}
 
 # Ruler configuration
 ruler:
@@ -213,6 +254,18 @@ ruler:
         name: ${object_store_loki_credentials_secret_name}
   extraArgs:
     - -config.expand-env=true
+  nodeSelector:
+    workload-class.mojaloop.io/MONITORING: "enabled"
+%{if length(tolerations) > 0 ~}
+  tolerations:
+%{ for t in tolerations ~}
+  - effect: "${t.effect}"
+    key: "${t.key}"
+    operator: "${t.operator}"
+    value: "${t.value}"
+%{ endfor ~}
+%{ endif ~}
+
 
 # Gateway configuration
 gateway:
@@ -222,10 +275,17 @@ gateway:
   service:
     type: ClusterIP
     port: 80
-  nodeAffinityPreset:
-    type: hard
-    key: workload-class.mojaloop.io/MONITORING
-    values: ["enabled"]
+  nodeSelector:
+    workload-class.mojaloop.io/MONITORING: "enabled"
+%{if length(tolerations) > 0 ~}
+  tolerations:
+%{ for t in tolerations ~}
+  - effect: "${t.effect}"
+    key: "${t.key}"
+    operator: "${t.operator}"
+    value: "${t.value}"
+%{ endfor ~}
+%{ endif ~}
 
 # Index Gateway (required for TSDB)
 indexGateway:
@@ -237,10 +297,17 @@ indexGateway:
   persistence:
     enabled: true
     size: 10Gi
-  nodeAffinityPreset:
-    type: hard
-    key: workload-class.mojaloop.io/MONITORING
-    values: ["enabled"]
+  nodeSelector:
+    workload-class.mojaloop.io/MONITORING: "enabled"
+%{if length(tolerations) > 0 ~}
+  tolerations:
+%{ for t in tolerations ~}
+  - effect: "${t.effect}"
+    key: "${t.key}"
+    operator: "${t.operator}"
+    value: "${t.value}"
+%{ endfor ~}
+%{ endif ~}
 
 # Chunks Cache (Memcached)
 chunksCache:
@@ -248,12 +315,34 @@ chunksCache:
   replicas: 1
   allocatedMemory: 1400
   maxItemMemory: 5
+  nodeSelector:
+    workload-class.mojaloop.io/MONITORING: "enabled"
+%{if length(tolerations) > 0 ~}
+  tolerations:
+%{ for t in tolerations ~}
+  - effect: "${t.effect}"
+    key: "${t.key}"
+    operator: "${t.operator}"
+    value: "${t.value}"
+%{ endfor ~}
+%{ endif ~}
 
 # Results Cache (Memcached)
 resultsCache:
   enabled: true
   replicas: 1
   allocatedMemory: 1024
+  nodeSelector:
+    workload-class.mojaloop.io/MONITORING: "enabled"
+%{if length(tolerations) > 0 ~}
+  tolerations:
+%{ for t in tolerations ~}
+  - effect: "${t.effect}"
+    key: "${t.key}"
+    operator: "${t.operator}"
+    value: "${t.value}"
+%{ endfor ~}
+%{ endif ~}
 
 # Monitoring
 monitoring:
@@ -268,6 +357,17 @@ monitoring:
 #Loki Canary
 lokiCanary:
   enabled: true
+  nodeSelector:
+    workload-class.mojaloop.io/MONITORING: "enabled"
+%{if length(tolerations) > 0 ~}
+  tolerations:
+%{ for t in tolerations ~}
+  - effect: "${t.effect}"
+    key: "${t.key}"
+    operator: "${t.operator}"
+    value: "${t.value}"
+%{ endfor ~}
+%{ endif ~}
 
 backend:
   replicas: 0

--- a/terraform/gitops/generate-files/templates/monitoring/install/values-prom-operator.yaml.tpl
+++ b/terraform/gitops/generate-files/templates/monitoring/install/values-prom-operator.yaml.tpl
@@ -115,6 +115,7 @@ prometheusOperator:
       memory: 100Mi
   admissionWebhooks:
     patch:
+      enabled: true
 %{if length(tolerations) > 0 ~}
       tolerations:
 %{ for t in tolerations ~}
@@ -123,6 +124,8 @@ prometheusOperator:
         operator: "${t.operator}"
         value: "${t.value}"
 %{ endfor ~}
+%{ else ~}
+      tolerations: []
 %{ endif ~}
 
 kubelet:

--- a/terraform/gitops/generate-files/templates/monitoring/install/values-prom-operator.yaml.tpl
+++ b/terraform/gitops/generate-files/templates/monitoring/install/values-prom-operator.yaml.tpl
@@ -5,11 +5,15 @@ alertmanager:
   
   alertmanagerSpec:
     externalUrl: "https://${alertmanager_fqdn}"
+%{if length(tolerations) > 0 ~}
     tolerations:
-    - key: "workload-class.mojaloop.io/MONITORING"
-      operator: "Equal"
-      value: "enabled"
-      effect: "NoSchedule"
+%{ for t in tolerations ~}
+    - effect: "${t.effect}"
+      key: "${t.key}"
+      operator: "${t.operator}"
+      value: "${t.value}"
+%{ endfor ~}
+%{ endif ~}
     storage:
       volumeClaimTemplate:
         spec:
@@ -50,11 +54,15 @@ prometheus:
           resources:
             requests:
               storage: ${prometheus_pvc_size}
+%{if length(tolerations) > 0 ~}
     tolerations:
-    - key: "workload-class.mojaloop.io/MONITORING"
-      operator: "Equal"
-      value: "enabled"
-      effect: "NoSchedule"
+%{ for t in tolerations ~}
+    - effect: "${t.effect}"
+      key: "${t.key}"
+      operator: "${t.operator}"
+      value: "${t.value}"
+%{ endfor ~}
+%{ endif ~}
     
     nodeSelector:
       workload-class.mojaloop.io/MONITORING: "enabled"
@@ -90,11 +98,15 @@ prometheus:
 
 prometheusOperator:
   enabled: true
+%{if length(tolerations) > 0 ~}
   tolerations:
-  - key: "workload-class.mojaloop.io/MONITORING"
-    operator: "Equal"
-    value: "enabled"
-    effect: "NoSchedule"
+%{ for t in tolerations ~}
+  - effect: "${t.effect}"
+    key: "${t.key}"
+    operator: "${t.operator}"
+    value: "${t.value}"
+%{ endfor ~}
+%{ endif ~}
   nodeSelector:
     workload-class.mojaloop.io/MONITORING: "enabled"
   resources:
@@ -103,11 +115,15 @@ prometheusOperator:
       memory: 100Mi
   admissionWebhooks:
     patch:
+%{if length(tolerations) > 0 ~}
       tolerations:
-      - key: "workload-class.mojaloop.io/MONITORING"
-        operator: "Equal"
-        value: "enabled"
-        effect: "NoSchedule"
+%{ for t in tolerations ~}
+      - effect: "${t.effect}"
+        key: "${t.key}"
+        operator: "${t.operator}"
+        value: "${t.value}"
+%{ endfor ~}
+%{ endif ~}
 
 kubelet:
   enabled: true
@@ -150,11 +166,15 @@ kubelet:
 
 kube-state-metrics:
   enabled: true
+%{if length(tolerations) > 0 ~}
   tolerations:
-  - key: "workload-class.mojaloop.io/MONITORING"
-    operator: "Equal"
-    value: "enabled"
-    effect: "NoSchedule"
+%{ for t in tolerations ~}
+  - effect: "${t.effect}"
+    key: "${t.key}"
+    operator: "${t.operator}"
+    value: "${t.value}"
+%{ endfor ~}
+%{ endif ~}
   prometheus:
     monitor:
       enabled: true
@@ -188,11 +208,15 @@ prometheus-node-exporter:
         - regex: endpoint|service
           action: labeldrop
   
+%{if length(tolerations) > 0 ~}
   tolerations:
-  - key: "workload-class.mojaloop.io/MONITORING"
-    operator: "Equal"
-    value: "enabled"
-    effect: "NoSchedule"
+%{ for t in tolerations ~}
+  - effect: "${t.effect}"
+    key: "${t.key}"
+    operator: "${t.operator}"
+    value: "${t.value}"
+%{ endfor ~}
+%{ endif ~}
 
 kubeApiServer:
   enabled: false 


### PR DESCRIPTION
This pull request updates the Kubernetes monitoring Helm chart templates to improve how node scheduling and tolerations are handled for monitoring workloads. The main changes involve replacing the previous use of `nodeAffinityPreset` with `nodeSelector` and making tolerations configurable and templated across all relevant monitoring components.

Key changes include:

**Standardization of Node Scheduling and Tolerations**

* Replaced all instances of `nodeAffinityPreset` with a `nodeSelector` targeting nodes labeled with `workload-class.mojaloop.io/MONITORING: "enabled"` in all major Loki and Alloy components, ensuring consistent node placement for monitoring workloads. [[1]](diffhunk://#diff-fdada582689788a67eb18e1a63e985a38b44b6a1d97986450181c8629563c424L107-R117) [[2]](diffhunk://#diff-fdada582689788a67eb18e1a63e985a38b44b6a1d97986450181c8629563c424L128-R145) [[3]](diffhunk://#diff-fdada582689788a67eb18e1a63e985a38b44b6a1d97986450181c8629563c424L146-R170) [[4]](diffhunk://#diff-fdada582689788a67eb18e1a63e985a38b44b6a1d97986450181c8629563c424L163-R194) [[5]](diffhunk://#diff-fdada582689788a67eb18e1a63e985a38b44b6a1d97986450181c8629563c424L180-R218) [[6]](diffhunk://#diff-fdada582689788a67eb18e1a63e985a38b44b6a1d97986450181c8629563c424L201-R246) [[7]](diffhunk://#diff-fdada582689788a67eb18e1a63e985a38b44b6a1d97986450181c8629563c424L225-R288) [[8]](diffhunk://#diff-fdada582689788a67eb18e1a63e985a38b44b6a1d97986450181c8629563c424L240-R345) [[9]](diffhunk://#diff-fdada582689788a67eb18e1a63e985a38b44b6a1d97986450181c8629563c424R360-R370) [[10]](diffhunk://#diff-7cfcf054ed12f5ec02831b5efcb3b75e56482357eeb64287e936a604fd7e63faR15-R30)

* Updated tolerations handling to use a templated approach: tolerations are now dynamically generated from a variable list, allowing for greater flexibility and customization in pod scheduling. If no tolerations are provided, the field is omitted or set to an empty array as appropriate. [[1]](diffhunk://#diff-fdada582689788a67eb18e1a63e985a38b44b6a1d97986450181c8629563c424L107-R117) [[2]](diffhunk://#diff-fdada582689788a67eb18e1a63e985a38b44b6a1d97986450181c8629563c424L128-R145) [[3]](diffhunk://#diff-fdada582689788a67eb18e1a63e985a38b44b6a1d97986450181c8629563c424L146-R170) [[4]](diffhunk://#diff-fdada582689788a67eb18e1a63e985a38b44b6a1d97986450181c8629563c424L163-R194) [[5]](diffhunk://#diff-fdada582689788a67eb18e1a63e985a38b44b6a1d97986450181c8629563c424L180-R218) [[6]](diffhunk://#diff-fdada582689788a67eb18e1a63e985a38b44b6a1d97986450181c8629563c424L201-R246) [[7]](diffhunk://#diff-fdada582689788a67eb18e1a63e985a38b44b6a1d97986450181c8629563c424L225-R288) [[8]](diffhunk://#diff-fdada582689788a67eb18e1a63e985a38b44b6a1d97986450181c8629563c424L240-R345) [[9]](diffhunk://#diff-fdada582689788a67eb18e1a63e985a38b44b6a1d97986450181c8629563c424R360-R370) [[10]](diffhunk://#diff-7cfcf054ed12f5ec02831b5efcb3b75e56482357eeb64287e936a604fd7e63faR15-R30) [[11]](diffhunk://#diff-d1109d5c03b73bcbb878847d9d3c4910fc59e341511e75044b6fb2d6e2b26ddbR8-R16) [[12]](diffhunk://#diff-d1109d5c03b73bcbb878847d9d3c4910fc59e341511e75044b6fb2d6e2b26ddbR57-R65) [[13]](diffhunk://#diff-d1109d5c03b73bcbb878847d9d3c4910fc59e341511e75044b6fb2d6e2b26ddbR101-R109) [[14]](diffhunk://#diff-d1109d5c03b73bcbb878847d9d3c4910fc59e341511e75044b6fb2d6e2b26ddbR118-R129) [[15]](diffhunk://#diff-d1109d5c03b73bcbb878847d9d3c4910fc59e341511e75044b6fb2d6e2b26ddbR172-R180) [[16]](diffhunk://#diff-d1109d5c03b73bcbb878847d9d3c4910fc59e341511e75044b6fb2d6e2b26ddbR214-R222)

**Consistent Application Across Monitoring Stack**

* Applied these changes to all major monitoring components, including Loki (ingester, distributor, querier, queryFrontend, queryScheduler, compactor, ruler, gateway, indexGateway, chunksCache, resultsCache, lokiCanary), Alloy, and Prometheus Operator stack components (alertmanager, prometheus, prometheusOperator, kubelet, kube-state-metrics, prometheus-node-exporter), ensuring uniform scheduling and toleration configuration. [[1]](diffhunk://#diff-fdada582689788a67eb18e1a63e985a38b44b6a1d97986450181c8629563c424L107-R117) [[2]](diffhunk://#diff-fdada582689788a67eb18e1a63e985a38b44b6a1d97986450181c8629563c424L128-R145) [[3]](diffhunk://#diff-fdada582689788a67eb18e1a63e985a38b44b6a1d97986450181c8629563c424L146-R170) [[4]](diffhunk://#diff-fdada582689788a67eb18e1a63e985a38b44b6a1d97986450181c8629563c424L163-R194) [[5]](diffhunk://#diff-fdada582689788a67eb18e1a63e985a38b44b6a1d97986450181c8629563c424L180-R218) [[6]](diffhunk://#diff-fdada582689788a67eb18e1a63e985a38b44b6a1d97986450181c8629563c424L201-R246) [[7]](diffhunk://#diff-fdada582689788a67eb18e1a63e985a38b44b6a1d97986450181c8629563c424L225-R288) [[8]](diffhunk://#diff-fdada582689788a67eb18e1a63e985a38b44b6a1d97986450181c8629563c424L240-R345) [[9]](diffhunk://#diff-fdada582689788a67eb18e1a63e985a38b44b6a1d97986450181c8629563c424R360-R370) [[10]](diffhunk://#diff-7cfcf054ed12f5ec02831b5efcb3b75e56482357eeb64287e936a604fd7e63faR15-R30) [[11]](diffhunk://#diff-d1109d5c03b73bcbb878847d9d3c4910fc59e341511e75044b6fb2d6e2b26ddbR8-R16) [[12]](diffhunk://#diff-d1109d5c03b73bcbb878847d9d3c4910fc59e341511e75044b6fb2d6e2b26ddbR57-R65) [[13]](diffhunk://#diff-d1109d5c03b73bcbb878847d9d3c4910fc59e341511e75044b6fb2d6e2b26ddbR101-R109) [[14]](diffhunk://#diff-d1109d5c03b73bcbb878847d9d3c4910fc59e341511e75044b6fb2d6e2b26ddbR118-R129) [[15]](diffhunk://#diff-d1109d5c03b73bcbb878847d9d3c4910fc59e341511e75044b6fb2d6e2b26ddbR172-R180) [[16]](diffhunk://#diff-d1109d5c03b73bcbb878847d9d3c4910fc59e341511e75044b6fb2d6e2b26ddbR214-R222)

**Template Logic Improvements**

* Improved Helm template logic to ensure tolerations are only set when provided, and defaults to an empty list or omits the field otherwise, preventing unnecessary or invalid configuration in the generated manifests. [[1]](diffhunk://#diff-fdada582689788a67eb18e1a63e985a38b44b6a1d97986450181c8629563c424L107-R117) [[2]](diffhunk://#diff-fdada582689788a67eb18e1a63e985a38b44b6a1d97986450181c8629563c424L128-R145) [[3]](diffhunk://#diff-fdada582689788a67eb18e1a63e985a38b44b6a1d97986450181c8629563c424L146-R170) [[4]](diffhunk://#diff-fdada582689788a67eb18e1a63e985a38b44b6a1d97986450181c8629563c424L163-R194) [[5]](diffhunk://#diff-fdada582689788a67eb18e1a63e985a38b44b6a1d97986450181c8629563c424L180-R218) [[6]](diffhunk://#diff-fdada582689788a67eb18e1a63e985a38b44b6a1d97986450181c8629563c424L201-R246) [[7]](diffhunk://#diff-fdada582689788a67eb18e1a63e985a38b44b6a1d97986450181c8629563c424L225-R288) [[8]](diffhunk://#diff-fdada582689788a67eb18e1a63e985a38b44b6a1d97986450181c8629563c424L240-R345) [[9]](diffhunk://#diff-fdada582689788a67eb18e1a63e985a38b44b6a1d97986450181c8629563c424R360-R370) [[10]](diffhunk://#diff-7cfcf054ed12f5ec02831b5efcb3b75e56482357eeb64287e936a604fd7e63faR15-R30) [[11]](diffhunk://#diff-d1109d5c03b73bcbb878847d9d3c4910fc59e341511e75044b6fb2d6e2b26ddbR8-R16) [[12]](diffhunk://#diff-d1109d5c03b73bcbb878847d9d3c4910fc59e341511e75044b6fb2d6e2b26ddbR57-R65) [[13]](diffhunk://#diff-d1109d5c03b73bcbb878847d9d3c4910fc59e341511e75044b6fb2d6e2b26ddbR101-R109) [[14]](diffhunk://#diff-d1109d5c03b73bcbb878847d9d3c4910fc59e341511e75044b6fb2d6e2b26ddbR118-R129) [[15]](diffhunk://#diff-d1109d5c03b73bcbb878847d9d3c4910fc59e341511e75044b6fb2d6e2b26ddbR172-R180) [[16]](diffhunk://#diff-d1109d5c03b73bcbb878847d9d3c4910fc59e341511e75044b6fb2d6e2b26ddbR214-R222)

These changes make the monitoring deployment more flexible and easier to configure for different environments and scheduling requirements.