### PR TITLE
fix(ci): fetch tags in cached repos before init

### DIFF
--- a/terraform/gitlab/ci-templates/bootstrap-v2/.gitlab-ci.yml
+++ b/terraform/gitlab/ci-templates/bootstrap-v2/.gitlab-ci.yml
@@ -118,6 +118,8 @@ init:
       aud: https://$VAULT_FQDN
   script:
     - !reference [.source, script]
+    # Fetch new tags in cached git repos to avoid stale tag errors
+    - find ${TF_ROOT} -path '*/.terragrunt-cache/*/.git' -type d -exec git -C {} fetch --tags --force \; 2>/dev/null || true
     # We need to reconfigure the initialized cache
     - terragrunt run-all init -upgrade -input=false -reconfigure
 


### PR DESCRIPTION
Fetch new tags in cached git repos before terragrunt init to avoid stale tag errors during CI runs.