### PR TITLE
fix: ArgoCD Application health check Lua string.match not available in sandbox

### DIFF
--- a/gitops/argo-apps/base/argocd-helm.yaml
+++ b/gitops/argo-apps/base/argocd-helm.yaml
@@ -79,11 +79,12 @@ spec:
                     hs = {}
                     hs.status = "Progressing"
                     hs.message = ""
+                    local errorTypes = {DeletionError = true, InvalidSpecError = true, ComparisonError = true, SyncError = true, UnknownError = true}
                     if obj.status ~= nil then
                       local status = obj.status
                       if status.conditions ~= nil then
                         for i, condition in ipairs(status.conditions) do
-                          if condition.type ~= nil and string.match(condition.type, '.*Error$') then
+                          if errorTypes[condition.type] then
                             hs.status = "Degraded"
                             hs.message = condition.message
                             return hs

--- a/gitops/argo-apps/base/sc-argocd.yaml
+++ b/gitops/argo-apps/base/sc-argocd.yaml
@@ -79,11 +79,12 @@ spec:
                     hs = {}
                     hs.status = "Progressing"
                     hs.message = ""
+                    local errorTypes = {DeletionError = true, InvalidSpecError = true, ComparisonError = true, SyncError = true, UnknownError = true}
                     if obj.status ~= nil then
                       local status = obj.status
                       if status.conditions ~= nil then
                         for i, condition in ipairs(status.conditions) do
-                          if condition.type ~= nil and string.match(condition.type, '.*Error$') then
+                          if errorTypes[condition.type] then
                             hs.status = "Degraded"
                             hs.message = condition.message
                             return hs


### PR DESCRIPTION
string.match() isn't available in ArgoCD's Lua sandbox, so using explicit error type lookup instead.