### PR TITLE
fix: netbird STUN connectivity - NLB health check and externalTrafficPolicy

### DIFF
--- a/gitops/applications/base/netbird-pre/stunner-crs.yaml
+++ b/gitops/applications/base/netbird-pre/stunner-crs.yaml
@@ -31,6 +31,7 @@ metadata:
   annotations:
     stunner.l7mp.io/service-type: NodePort
     stunner.l7mp.io/nodeport: '{"udp-listener": ${ARGOCD_ENV_stunner_nodeport_port} }'
+    stunner.l7mp.io/external-traffic-policy: local
 spec:
   gatewayClassName: stunner-gatewayclass
   listeners:
@@ -50,3 +51,21 @@ spec:
     - backendRefs:
         - name: udp-gateway
           namespace: "${ARGOCD_ENV_stunner_impl_namespace}"
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: stunner-health
+  namespace: "${ARGOCD_ENV_stunner_impl_namespace}"
+spec:
+  type: NodePort
+  externalTrafficPolicy: Local
+  selector:
+    app: stunner
+    stunner.l7mp.io/related-gateway-name: udp-gateway
+    stunner.l7mp.io/related-gateway-namespace: "${ARGOCD_ENV_stunner_impl_namespace}"
+  ports:
+    - name: health
+      port: 8086
+      targetPort: 8086
+      nodePort: ${ARGOCD_ENV_stunner_health_nodeport}

--- a/gitops/argo-apps/base/netbird-pre.yaml
+++ b/gitops/argo-apps/base/netbird-pre.yaml
@@ -75,6 +75,9 @@ spec:
           - name: "stunner_nodeport_port"
             value: "${ARGOCD_ENV_security_netbird_stunner_nodeport_port}"
 
+          - name: "stunner_health_nodeport"
+            value: "${ARGOCD_ENV_security_netbird_stunner_health_nodeport}"
+
           - name: "stunner_gateway_operator_helm_version"
             value: "${ARGOCD_ENV_security_netbird_stunner_gateway_operator_helm_version}"
 

--- a/terraform/aws/base-k8s/loadbalancer.tf
+++ b/terraform/aws/base-k8s/loadbalancer.tf
@@ -175,11 +175,15 @@ resource "aws_lb_target_group" "wireguard" {
   protocol = "UDP"
   vpc_id   = module.base_infra.vpc_id
 
-  # TODO: can't health check against a UDP port, but need to have a health check when backend is an instance.
-  # check tcp port 80 (ingress) for now, but probably need to add a http sidecar or something to act as a health check for wireguard
   health_check {
-    protocol = "TCP"
-    port     = var.target_group_external_https_port
+    protocol            = "HTTP"
+    port                = var.wireguard_health_port
+    path                = "/ready"
+    interval            = 10
+    timeout             = 6
+    healthy_threshold   = 3
+    unhealthy_threshold = 3
+    matcher             = "200"
   }
 
   tags = merge({ Name = "${local.base_domain}-wireguard" }, local.common_tags)

--- a/terraform/aws/base-k8s/outputs.tf
+++ b/terraform/aws/base-k8s/outputs.tf
@@ -53,6 +53,9 @@ output "target_group_external_health_port" {
 output "target_group_vpn_port" {
   value = var.wireguard_port
 }
+output "target_group_vpn_health_port" {
+  value = var.wireguard_health_port
+}
 output "private_network_cidr" {
   value = var.vpc_cidr
 }

--- a/terraform/aws/base-k8s/security-groups.tf
+++ b/terraform/aws/base-k8s/security-groups.tf
@@ -71,6 +71,15 @@ resource "aws_security_group_rule" "ingress_vpn" {
   security_group_id = aws_security_group.ingress.id
 }
 
+resource "aws_security_group_rule" "ingress_vpn_health" {
+  type              = "ingress"
+  from_port         = var.wireguard_health_port
+  to_port           = var.wireguard_health_port
+  protocol          = "TCP"
+  cidr_blocks       = ["0.0.0.0/0"]
+  security_group_id = aws_security_group.ingress.id
+}
+
 resource "aws_security_group_rule" "ingress_self" {
   type              = "ingress"
   from_port         = 0

--- a/terraform/aws/base-k8s/variables.tf
+++ b/terraform/aws/base-k8s/variables.tf
@@ -95,6 +95,13 @@ variable "wireguard_port" {
   description = "wireguard_port"
   default     = 31821
 }
+
+variable "wireguard_health_port" {
+  type        = number
+  description = "wireguard_health_port for NLB health checks"
+  default     = 31822
+}
+
 variable "target_group_internal_https_port" {
   type        = number
   description = "target_group_internal_https_port"

--- a/terraform/ccnew/ansible-k8s-deploy/templates/argoapps.yaml.tpl
+++ b/terraform/ccnew/ansible-k8s-deploy/templates/argoapps.yaml.tpl
@@ -303,6 +303,7 @@ argocd_override:
           pvc_size: "${zitadel_db_storage_size}"
         netbird:
           stunner_nodeport_port: "'${wireguard_ingress_port}'"
+          stunner_health_nodeport: "'${wireguard_health_port}'"
           terraform_modules_tag: "${iac_terraform_modules_tag}"
           public_ingress_access_domain: "${netbird_public_access}"
           helm_version: "${netbird_helm_version}"

--- a/terraform/ccnew/ansible-k8s-deploy/terragrunt.hcl
+++ b/terraform/ccnew/ansible-k8s-deploy/terragrunt.hcl
@@ -101,6 +101,7 @@ inputs = {
     internal_load_balancer_dns        = dependency.k8s_deploy.outputs.internal_load_balancer_dns
     external_load_balancer_dns        = dependency.k8s_deploy.outputs.external_load_balancer_dns
     wireguard_ingress_port            = dependency.k8s_deploy.outputs.target_group_vpn_port
+    wireguard_health_port             = dependency.k8s_deploy.outputs.target_group_vpn_health_port
     external_dns_cloud_role           = dependency.k8s_deploy.outputs.external_dns_cloud_role
     cert_manager_cloud_policy         = dependency.k8s_deploy.outputs.ext_dns_cloud_policy
     cloud_platform_api_client_id      = dependency.k8s_deploy.outputs.secrets_var_map[dependency.k8s_deploy.outputs.secrets_key_map.iac_user_cred_id_key]

--- a/terraform/ccnew/ansible-k8s-deploy/terragrunt.hcl
+++ b/terraform/ccnew/ansible-k8s-deploy/terragrunt.hcl
@@ -36,6 +36,7 @@ dependency "k8s_deploy" {
     target_group_external_http_port = 0
     target_group_external_health_port = 0
     target_group_vpn_port = 0
+    target_group_vpn_health_port = 0
     internal_load_balancer_dns = "null"
     external_load_balancer_dns = "null"
     external_load_balancer_private_ip = "null"
@@ -51,7 +52,7 @@ dependency "k8s_deploy" {
     private_dns_zone_id = "null"
   }
   mock_outputs_allowed_terraform_commands = ["init", "validate", "plan", "show"]
-  mock_outputs_merge_strategy_with_state  = "shallow"
+  mock_outputs_merge_strategy_with_state  = "deep"
 }
 
 inputs = {


### PR DESCRIPTION
NLB health check was using Istio port (32443) instead of STUNner health port, so all nodes appeared healthy. With single STUNner replica, 2/3 of STUN requests hit nodes without the pod and failed.

Changes:
- Add `externalTrafficPolicy: Local` to preserve client IP for STUN (required for correct reflexive address discovery)
- Create health check service exposing STUNner port 8086 as NodePort 31822
- Update NLB target group to health check on /ready endpoint
- Add security group rule for health check port

Now NLB routes only to nodes with healthy STUNner pod.