### PR TITLE
fix(nlb): disable preserve_client_ip on internal NLB for Netbird VPN

### DIFF
--- a/terraform/aws/base-k8s/loadbalancer.tf
+++ b/terraform/aws/base-k8s/loadbalancer.tf
@@ -20,10 +20,11 @@ resource "aws_lb_listener" "internal_kubeapi" {
 }
 
 resource "aws_lb_target_group" "internal_kubeapi" {
-  port     = var.kubeapi_port
-  protocol = "TCP"
-  vpc_id   = module.base_infra.vpc_id
-  tags     = merge({ Name = "${local.base_domain}-internal-kubeapi" }, local.common_tags)
+  port               = var.kubeapi_port
+  protocol           = "TCP"
+  vpc_id             = module.base_infra.vpc_id
+  preserve_client_ip = false # Required for Netbird VPN access
+  tags               = merge({ Name = "${local.base_domain}-internal-kubeapi" }, local.common_tags)
 }
 
 resource "aws_lb_listener" "internal_https" {
@@ -38,10 +39,10 @@ resource "aws_lb_listener" "internal_https" {
 }
 
 resource "aws_lb_target_group" "internal_https" {
-  port     = var.target_group_internal_https_port
-  protocol = "TCP"
-  vpc_id   = module.base_infra.vpc_id
-  preserve_client_ip = false
+  port               = var.target_group_internal_https_port
+  protocol           = "TCP"
+  vpc_id             = module.base_infra.vpc_id
+  preserve_client_ip = false # Required for Netbird VPN access
   proxy_protocol_v2  = false
 
   health_check {
@@ -70,9 +71,10 @@ resource "aws_lb_listener" "internal_http" {
   }
 }
 resource "aws_lb_target_group" "internal_http" {
-  port     = var.target_group_internal_http_port
-  protocol = "TCP"
-  vpc_id   = module.base_infra.vpc_id
+  port               = var.target_group_internal_http_port
+  protocol           = "TCP"
+  vpc_id             = module.base_infra.vpc_id
+  preserve_client_ip = false # Required for Netbird VPN access
 
   health_check {
     interval            = 10
@@ -94,10 +96,11 @@ resource "aws_lb_target_group" "internal_http" {
 
 
 resource "aws_lb" "lb" {
-  internal           = false
-  load_balancer_type = "network"
-  subnets            = module.base_infra.public_subnets
-  tags               = merge({ Name = "${local.base_domain}-public" }, local.common_tags)
+  internal                         = false
+  load_balancer_type               = "network"
+  enable_cross_zone_load_balancing = true
+  subnets                          = module.base_infra.public_subnets
+  tags                             = merge({ Name = "${local.base_domain}-public" }, local.common_tags)
 }
 
 resource "aws_lb_listener" "external_https" {

--- a/terraform/aws/eks/loadbalancer.tf
+++ b/terraform/aws/eks/loadbalancer.tf
@@ -20,10 +20,11 @@ resource "aws_lb_listener" "internal_kubeapi" {
 }
 
 resource "aws_lb_target_group" "internal_kubeapi" {
-  port     = var.kubeapi_port
-  protocol = "TCP"
-  vpc_id   = module.base_infra.vpc_id
-  tags = merge({ Name = "${local.base_domain}-internal-kubeapi" }, local.common_tags)
+  port               = var.kubeapi_port
+  protocol           = "TCP"
+  vpc_id             = module.base_infra.vpc_id
+  preserve_client_ip = false # Required for Netbird VPN access
+  tags               = merge({ Name = "${local.base_domain}-internal-kubeapi" }, local.common_tags)
 }
 
 resource "aws_lb_listener" "internal_https" {
@@ -41,7 +42,7 @@ resource "aws_lb_target_group" "internal_https" {
   port     = var.target_group_internal_https_port
   protocol = "TCP"
   vpc_id   = module.base_infra.vpc_id
-  preserve_client_ip = false
+  preserve_client_ip = false # Required for Netbird VPN access
   proxy_protocol_v2  = false
 
   health_check {
@@ -70,9 +71,10 @@ resource "aws_lb_listener" "internal_http" {
   }
 }
 resource "aws_lb_target_group" "internal_http" {
-  port     = var.target_group_internal_http_port
-  protocol = "TCP"
-  vpc_id   = module.base_infra.vpc_id
+  port               = var.target_group_internal_http_port
+  protocol           = "TCP"
+  vpc_id             = module.base_infra.vpc_id
+  preserve_client_ip = false # Required for Netbird VPN access
 
   health_check {
     interval            = 10


### PR DESCRIPTION
With preserve_client_ip=true on internal NLB, responses from target nodes bypass the NLB and go directly to the source IP. When traffic comes through Netbird VPN (which uses SNAT), this causes conntrack mismatch - client expects reply from NLB IP but receives it from target node directly.

Result: ~25% timeout rate for kubectl and internal HTTP/HTTPS traffic via VPN.

Setting preserve_client_ip=false on internal NLB target groups ensures responses go back through NLB, fixing the conntrack flow. Internal traffic doesn't need client IP preservation anyway.