### PR TITLE
fix: update tolerations handling in Kafka node pool configuration

### DIFF
--- a/terraform/gitops/stateful-resources/templates/stateful-resources/strimzi/kafka/kafka-with-dual-role-nodes.yaml.tpl
+++ b/terraform/gitops/stateful-resources/templates/stateful-resources/strimzi/kafka/kafka-with-dual-role-nodes.yaml.tpl
@@ -27,6 +27,14 @@ spec:
           operator: Exists
           effect: NoExecute
           tolerationSeconds: 600
+%{if length(tolerations) > 0 ~}
+%{ for t in tolerations ~}
+        - effect: "${t.effect}"
+          key: "${t.key}"
+          operator: "${t.operator}"
+          value: "${t.value}"
+%{ endfor ~}
+%{ endif ~}
       topologySpreadConstraints:
         - maxSkew: 1
           topologyKey: kubernetes.io/hostname
@@ -44,15 +52,6 @@ spec:
       affinity:
         ${indent(8, yamlencode(node_pool_affinity))}
 # %{ endif }
-%{if length(tolerations) > 0 ~}
-      tolerations:
-%{ for t in tolerations ~}
-        - effect: "${t.effect}"
-          key: "${t.key}"
-          operator: "${t.operator}"
-          value: "${t.value}"
-%{ endfor ~}
-%{ endif ~}
 ---
 apiVersion: kafka.strimzi.io/v1beta2
 kind: Kafka


### PR DESCRIPTION
This change fixes an invalid YAML rendering issue in the KafkaNodePool pod template where tolerations were defined twice (a static entry + a conditional block).
The duplication produced invalid manifests during Kustomize/Helm rendering, causing ArgoCD manifest generation failures.

The fix merges the static Netbird toleration with any user-defined tolerations into a single tolerations list.