### PR TITLE
env onboard tag

### DIFF
--- a/terraform/ccnew/ansible-k8s-deploy/templates/argoapps.yaml.tpl
+++ b/terraform/ccnew/ansible-k8s-deploy/templates/argoapps.yaml.tpl
@@ -582,7 +582,7 @@ argocd_override:
           ceph_bucket_max_size:  "${ceph_bucket_max_size}"
           env_token_ttl: "${env_token_ttl}"
         onboard:
-          terraform_modules_tag: "${iac_terraform_modules_tag}"
+          terraform_modules_tag: "${env_onboard_iac_terraform_modules_tag != "" ? env_onboard_iac_terraform_modules_tag : iac_terraform_modules_tag}"
           object_storage_provider: "${object_storage_provider}"
           cloud_platform: "${cloud_platform}"
           cloud_region: "${cloud_region}"

--- a/terraform/ccnew/default-config/common-vars.yaml
+++ b/terraform/ccnew/default-config/common-vars.yaml
@@ -631,3 +631,5 @@ env_loki_bucket_storage_size: "30Gi"
 
 # env vault backup
 vault_backup_bucket_storage_size: "10Gi"
+
+env_onboard_iac_terraform_modules_tag: ""


### PR DESCRIPTION
This pull request introduces a configurable override for the `terraform_modules_tag` used during onboarding by allowing the value to be set via a new environment variable. This gives more flexibility for deployments that require a different Terraform modules tag for onboarding, without affecting the default.

Configuration improvements:

* Added a new variable `env_onboard_iac_terraform_modules_tag` to `common-vars.yaml` to allow overriding the default `terraform_modules_tag` for onboarding.
* Updated `argoapps.yaml.tpl` to use `env_onboard_iac_terraform_modules_tag` if set; otherwise, it falls back to the default `iac_terraform_modules_tag`.