### PR TITLE
Make cluster name dynamic and apply minor fixes

### DIFF
--- a/gitops/applications/overlays/cloud_provider/private-cloud/storage-provider/capi-post-config/sc-bootstrap.yaml
+++ b/gitops/applications/overlays/cloud_provider/private-cloud/storage-provider/capi-post-config/sc-bootstrap.yaml
@@ -320,6 +320,9 @@ spec:
             - name: "monitoring_alloy_limits_cpu"
               value: "${ARGOCD_ENV_monitoring_alloy_limits_cpu}"
 
+            - name: "capi_cluster_name"
+              value: "${ARGOCD_ENV_capi_cluster_name}"
+
   providerConfigsRef:
     scK8sProviderName: sc-kubernetes-provider
     scHelmProviderName: sc-helm-provider

--- a/gitops/applications/overlays/cloud_provider/private-cloud/storage-provider/monitoring/alloy-config.alloy
+++ b/gitops/applications/overlays/cloud_provider/private-cloud/storage-provider/monitoring/alloy-config.alloy
@@ -72,7 +72,7 @@ stage.limit {
 
 stage.static_labels {
     values = {
-    cluster = "storage",
+    cluster = env("ALLOY_CLUSTER_NAME"),
     }
 }
 

--- a/gitops/applications/overlays/cloud_provider/private-cloud/storage-provider/monitoring/values-alloy.yaml
+++ b/gitops/applications/overlays/cloud_provider/private-cloud/storage-provider/monitoring/values-alloy.yaml
@@ -8,6 +8,8 @@ alloy:
       value: "${ARGOCD_ENV_alloy_log_burst_rate_limit_per_pod}"
     - name: LOKI_ENDPOINT
       value: "${ARGOCD_ENV_alloy_target_loki_endpoint}"
+    - name: ALLOY_CLUSTER_NAME
+      value: ${ARGOCD_ENV_capi_cluster_name}
   resources:
     requests:
       cpu: 100m

--- a/gitops/applications/overlays/cloud_provider/private-cloud/storage-provider/monitoring/values-alloy.yaml
+++ b/gitops/applications/overlays/cloud_provider/private-cloud/storage-provider/monitoring/values-alloy.yaml
@@ -9,7 +9,7 @@ alloy:
     - name: LOKI_ENDPOINT
       value: "${ARGOCD_ENV_alloy_target_loki_endpoint}"
     - name: ALLOY_CLUSTER_NAME
-      value: ${ARGOCD_ENV_capi_cluster_name}
+      value: "${ARGOCD_ENV_capi_cluster_name}"
   resources:
     requests:
       cpu: 100m

--- a/gitops/applications/overlays/cloud_provider/private-cloud/storage-provider/monitoring/values-kube-prometheus.yaml
+++ b/gitops/applications/overlays/cloud_provider/private-cloud/storage-provider/monitoring/values-kube-prometheus.yaml
@@ -37,7 +37,7 @@ prometheus:
     retention: ${ARGOCD_ENV_prometheus_retention_period}
     
     externalLabels:
-      cluster: ${ARGOCD_ENV_cluster_label_value}
+      cluster: ${ARGOCD_ENV_capi_cluster_name}
     
     disableCompaction: false
     additionalArgs:

--- a/gitops/argo-apps/base/sc-monitoring.yaml
+++ b/gitops/argo-apps/base/sc-monitoring.yaml
@@ -71,4 +71,6 @@ spec:
           value: "200"
         - name: "alloy_log_burst_rate_limit_per_pod"
           value: "500"
+        - name: "capi_cluster_name"
+          value: "${ARGOCD_ENV_capi_cluster_name}"
 


### PR DESCRIPTION
This pull request updates the way the cluster name is configured and passed into the Alloy monitoring configuration for the private cloud storage provider. The main change is to make the cluster label dynamic by sourcing it from an environment variable, which improves flexibility and consistency across environments.

Configuration improvements:

* The `cluster` static label in `alloy-config.alloy` is now set using the `ALLOY_CLUSTER_NAME` environment variable instead of the hardcoded value `"storage"`.
* The `ALLOY_CLUSTER_NAME` environment variable is now passed into the Alloy deployment via the `values-alloy.yaml` file, mapping it from the `ARGOCD_ENV_capi_cluster_name` environment variable.