### PR TITLE
Feat/iad 701

### DIFF
--- a/terraform/gitops/stateful-resources/stateful-resources-config.tf
+++ b/terraform/gitops/stateful-resources/stateful-resources-config.tf
@@ -298,6 +298,8 @@ resource "local_file" "dbaas-crs-mongodb" {
         replset_requests_memory      = each.value.dbaas_resource_config.replset_requests_memory
         configsvr_expose_enabled     = each.value.dbaas_resource_config.configsvr_expose_enabled
         configsvr_expose_type        = each.value.dbaas_resource_config.configsvr_expose_type
+        replsets_exposed_enabled     = each.value.dbaas_resource_config.replsets_exposed_enabled
+        replsets_expose_type         = each.value.dbaas_resource_config.replsets_expose_type
         replset_storage              = each.value.dbaas_resource_config.replset_storage
         sharding_enabled             = each.value.dbaas_resource_config.sharding_enabled
         configsvr_size               = each.value.dbaas_resource_config.configsvr_size

--- a/terraform/gitops/stateful-resources/stateful-resources-config.tf
+++ b/terraform/gitops/stateful-resources/stateful-resources-config.tf
@@ -298,7 +298,7 @@ resource "local_file" "dbaas-crs-mongodb" {
         replset_requests_memory      = each.value.dbaas_resource_config.replset_requests_memory
         configsvr_expose_enabled     = each.value.dbaas_resource_config.configsvr_expose_enabled
         configsvr_expose_type        = each.value.dbaas_resource_config.configsvr_expose_type
-        replsets_exposed_enabled     = each.value.dbaas_resource_config.replsets_exposed_enabled
+        replsets_expose_enabled      = each.value.dbaas_resource_config.replsets_exposed_enabled
         replsets_expose_type         = each.value.dbaas_resource_config.replsets_expose_type
         replset_storage              = each.value.dbaas_resource_config.replset_storage
         sharding_enabled             = each.value.dbaas_resource_config.sharding_enabled

--- a/terraform/gitops/stateful-resources/stateful-resources-config.tf
+++ b/terraform/gitops/stateful-resources/stateful-resources-config.tf
@@ -298,7 +298,7 @@ resource "local_file" "dbaas-crs-mongodb" {
         replset_requests_memory      = each.value.dbaas_resource_config.replset_requests_memory
         configsvr_expose_enabled     = each.value.dbaas_resource_config.configsvr_expose_enabled
         configsvr_expose_type        = each.value.dbaas_resource_config.configsvr_expose_type
-        replsets_expose_enabled      = each.value.dbaas_resource_config.replsets_exposed_enabled
+        replsets_expose_enabled      = each.value.dbaas_resource_config.replsets_expose_enabled
         replsets_expose_type         = each.value.dbaas_resource_config.replsets_expose_type
         replset_storage              = each.value.dbaas_resource_config.replset_storage
         sharding_enabled             = each.value.dbaas_resource_config.sharding_enabled

--- a/terraform/gitops/stateful-resources/templates/stateful-resources/dbaas/mongodb/db-cluster.yaml.tpl
+++ b/terraform/gitops/stateful-resources/templates/stateful-resources/dbaas/mongodb/db-cluster.yaml.tpl
@@ -40,8 +40,8 @@ spec:
       name: ${replset_name}
       size: ${replset_size}
       expose:
-        enabled: false
-        type: ClusterIP
+        enabled: ${replsets_expose_enabled}
+        type: ${replsets_expose_type}
       resources:
         limits:
           cpu: ${replset_limits_cpu}

--- a/terraform/k8s/default-config/common-vars.yaml
+++ b/terraform/k8s/default-config/common-vars.yaml
@@ -109,7 +109,7 @@ crossplane_packages_objectstores_version: "v0.2.0"
 crossplane_packages_aws_documentdb_version: "v0.6.0"
 crossplane_packages_aws_rds_version: "v0.4.0"
 crossplane_packages_sc_mysql_version: "v0.9.0"
-crossplane_packages_sc_mongodb_version: "v0.5.1"
+crossplane_packages_sc_mongodb_version: "v0.5.1-pr121-23542530747"
 max_pods_per_node: 110
 velero_plugin_version: 'v1.12.1'
 velero_helm_version: '10.0.1'

--- a/terraform/k8s/default-config/mojaloop-stateful-resources-monolith-databases.yaml
+++ b/terraform/k8s/default-config/mojaloop-stateful-resources-monolith-databases.yaml
@@ -315,7 +315,7 @@ common_mongodb:
     replset_requests_cpu: "50m"
     replset_requests_memory: "0.5G"
     replset_storage: 30Gi
-    replsets_exposed_enabled: true
+    replsets_expose_enabled: true
     replsets_expose_type: "LoadBalancer"
 
     # Sharding inputs

--- a/terraform/k8s/default-config/mojaloop-stateful-resources-monolith-databases.yaml
+++ b/terraform/k8s/default-config/mojaloop-stateful-resources-monolith-databases.yaml
@@ -315,6 +315,8 @@ common_mongodb:
     replset_requests_cpu: "50m"
     replset_requests_memory: "0.5G"
     replset_storage: 30Gi
+    replsets_exposed_enabled: true
+    replsets_expose_type: "LoadBalancer"
 
     # Sharding inputs
     sharding_enabled: true


### PR DESCRIPTION
This pull request enhances the configuration options for MongoDB replica sets in our Terraform-managed Kubernetes resources. It introduces new parameters to control how replica sets are exposed, making the setup more flexible and customizable. Additionally, it updates the version of the `crossplane_packages_sc_mongodb` package to include a specific pre-release.

**MongoDB Replica Set Exposure Configuration:**

* Added `replsets_expose_enabled` and `replsets_expose_type` parameters to the MongoDB resource configuration, allowing control over whether replica sets are exposed and by which service type (e.g., `LoadBalancer`). (`terraform/k8s/default-config/mojaloop-stateful-resources-monolith-databases.yaml`, `terraform/gitops/stateful-resources/stateful-resources-config.tf`) [[1]](diffhunk://#diff-40a6e76cafb4eac390867bc4d79f5e2a47188488486370a4d1ea7196c80eb8a6R318-R319) [[2]](diffhunk://#diff-f877f8ca88cbea949045c4693237ab86ec3566c22d5359a000f29b737205813dR301-R302)
* Updated the MongoDB Helm template to use these new parameters for the `expose` section of each replica set, instead of hardcoding values. (`terraform/gitops/stateful-resources/templates/stateful-resources/dbaas/mongodb/db-cluster.yaml.tpl`)

**Dependency Version Update:**

* Bumped the `crossplane_packages_sc_mongodb_version` to `v0.5.1-pr121-23542530747` for improved compatibility or features. (`terraform/k8s/default-config/common-vars.yaml`)